### PR TITLE
Don't skip interactive mode tests on MacOS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.3.0"
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"

--- a/src/PkgTemplates.jl
+++ b/src/PkgTemplates.jl
@@ -2,7 +2,6 @@ module PkgTemplates
 
 using AutoHashEquals
 using Dates
-using Distributed
 using InteractiveUtils
 using LibGit2
 using Mustache

--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -213,14 +213,14 @@ function badges(p::GenericPlugin, user::AbstractString, pkg_name::AbstractString
 end
 
 """
-    interactive(t::Type{<:Plugin}; file::Union{AbstractString, Nothing}="") -> Plugin
+    interactive(T::Type{<:Plugin}; file::Union{AbstractString, Nothing}="") -> Plugin
 
-Interactively create a plugin of type `t`, where `file` is the plugin type's default
+Interactively create a plugin of type `T`, where `file` is the plugin type's default
 config template with a non-standard name (for `MyPlugin`, this is anything but
 "myplugin.yml").
 """
-function interactive(t::Type{<:GenericPlugin}; file::Union{AbstractString, Nothing}="")
-    name = string(nameof(t))
+function interactive(T::Type{<:GenericPlugin}; file::Union{AbstractString, Nothing}="")
+    name = string(nameof(T))
     # By default, we expect the default plugin file template for a plugin called
     # "MyPlugin" to be called "myplugin.yml".
     fn = file != nothing && isempty(file) ? "$(lowercase(name)).yml" : file
@@ -242,5 +242,5 @@ function interactive(t::Type{<:GenericPlugin}; file::Union{AbstractString, Nothi
         config_file
     end
 
-    return t(; config_file=config_file)
+    return T(; config_file=config_file)
 end

--- a/src/plugins/coveralls.jl
+++ b/src/plugins/coveralls.jl
@@ -40,4 +40,4 @@ file to generated repositories, and an appropriate badge to the README. Also upd
     end
 end
 
-interactive(plugin_type::Type{Coveralls}) = interactive(plugin_type; file=nothing)
+interactive(::Type{Coveralls}) = interactive(Coveralls; file=nothing)

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -115,9 +115,3 @@ function Base.show(io::IO, p::Documenter)
     print(io, "$spc→ $n gitignore entrie$s")
     n > 0 && print(io, ": $(join(map(g -> "\"$g\"", p.gitignore), ", "))")
 end
-
-function interactive(T::Type{<:Documenter})
-    name = string(nameof(T))
-    print("$name: Enter any Documenter asset files (separated by spaces) []: ")
-    return T(; assets=string.(split(readline())))
-end

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -116,8 +116,8 @@ function Base.show(io::IO, p::Documenter)
     n > 0 && print(io, ": $(join(map(g -> "\"$g\"", p.gitignore), ", "))")
 end
 
-function interactive(t::Type{<:Documenter})
-    name = string(nameof(t))
+function interactive(T::Type{<:Documenter})
+    name = string(nameof(T))
     print("$name: Enter any Documenter asset files (separated by spaces) []: ")
-    return t(; assets=string.(split(readline())))
+    return T(; assets=string.(split(readline())))
 end

--- a/src/plugins/githubpages.jl
+++ b/src/plugins/githubpages.jl
@@ -61,3 +61,8 @@ function gen_plugin(p::GitHubPages, t::Template, pkg_name::AbstractString)
     end
     return ["docs/"]
 end
+
+function interactive(::Type{GitHubPages})
+    print("GitHubPages: Enter any Documenter asset files (separated by spaces) []: ")
+    return GitHubPages(; assets=string.(split(readline())))
+end

--- a/src/plugins/travisci.jl
+++ b/src/plugins/travisci.jl
@@ -41,4 +41,4 @@ generated repositories, and an appropriate badge to the README.
     end
 end
 
-interactive(plugin_type::Type{TravisCI}) = interactive(plugin_type; file="travis.yml")
+interactive(::Type{TravisCI}) = interactive(TravisCI; file="travis.yml")

--- a/src/template.jl
+++ b/src/template.jl
@@ -126,7 +126,7 @@ function interactive_template(; fast::Bool=false)
     @info "Default values are shown in [brackets]"
     # Getting the leaf types in a separate thread eliminates an awkward wait after
     # "Select plugins" is printed.
-    plugin_types = @spawn leaves(Plugin)
+    plugin_types = @async leaves(Plugin)
     kwargs = Dict{Symbol, Any}()
 
     default_user = LibGit2.getconfig("github.user", "")
@@ -205,13 +205,11 @@ function interactive_template(; fast::Bool=false)
     type_names = map(t -> split(string(t), ".")[end], plugin_types)
     menu = MultiSelectMenu(String.(type_names); pagesize=length(type_names))
     selected = collect(request(menu))
-    kwargs[:plugins] = Vector{Plugin}(
-        map(t -> interactive(t), getindex(plugin_types, selected))
-    )
+    kwargs[:plugins] = Vector{Plugin}(map(interactive, getindex(plugin_types, selected)))
 
     return Template(; kwargs...)
 end
 
-leaves(t::Type)::Vector{DataType} = isconcretetype(t) ? [t] : vcat(leaves.(subtypes(t))...)
+leaves(T::Type)::Vector{DataType} = isconcretetype(T) ? [T] : vcat(leaves.(subtypes(T))...)
 
 missingopt(name) = @warn "Git config option '$name' missing, package generation will fail unless you supply a GitConfig"

--- a/test/interactive/interactive.jl
+++ b/test/interactive/interactive.jl
@@ -1,58 +1,56 @@
-# TerminalMenus.jl has issues in environments without a TTY,
-# which seems to be the case in Travis CI OSX builds.
-# https://travis-ci.org/invenia/PkgTemplates.jl/jobs/267682403#L115
-# https://github.com/nick-paul/TerminalMenus.jl/issues/5
-# This also affects any time we write to stdin.buffer, because
-# IOStreams do not have that attribute.
-# Therefore, we skip any interactive tests on OSX builds.
+@testset "Interactive mode" begin
+    @testset "Template creation" begin
+        write(stdin.buffer, "$me\n\n\r\n\n\nd")
+        t = interactive_template()
+        @test t.user == me
+        @test t.host == "github.com"
+        @test isempty(t.license)
+        @test t.authors == LibGit2.getconfig("user.name", "")
+        @test t.dir == default_dir
+        @test t.julia_version == VERSION
+        @test !t.ssh
+        @test isempty(t.plugins)
 
-@testset "Interactive template creation" begin
-    write(stdin.buffer, "$me\n\n\r\n\n\nd")
-    t = interactive_template()
-    @test t.user == me
-    @test t.host == "github.com"
-    @test isempty(t.license)
-    @test t.authors == LibGit2.getconfig("user.name", "")
-    @test t.dir == default_dir
-    @test t.julia_version == VERSION
-    @test !t.ssh
-    @test isempty(t.plugins)
+        if isempty(LibGit2.getconfig("github.user", ""))
+            write(stdin.buffer, "\n")
+            @test_throws ArgumentError t = interactive_template()
+        end
 
-    if isempty(LibGit2.getconfig("github.user", ""))
-        write(stdin.buffer, "\n")
-        @test_throws ArgumentError t = interactive_template()
+        down = '\x1b' * "[B"  # Down array key.
+        write(stdin.buffer, "$me\ngitlab.com\n$down\r$me\n$test_file\n0.5\nyes\n$down\r$down\rd\n\n")
+        t = interactive_template()
+        @test t.user == me
+        @test t.host == "gitlab.com"
+        # Not sure if the order the licenses are displayed in is consistent.
+        @test !isempty(t.license)
+        @test t.authors == me
+        @test t.dir == abspath(test_file)
+        @test t.julia_version == v"0.5.0"
+        @test t.ssh
+        # Like above, not sure which plugins this will generate.
+        @test length(t.plugins) == 2
+
+        write(stdin.buffer, "$me\nd")
+        t = interactive_template(; fast=true)
+        @test t.user == me
+        @test t.host == "github.com"
+        @test t.license == "MIT"
+        @test t.authors == LibGit2.getconfig("user.name", "")
+        @test t.dir == default_dir
+        @test t.julia_version == VERSION
+        @test !t.ssh
+        @test isempty(t.plugins)
+        println()
     end
 
-    down = '\x1b' * "[B"  # Down array key.
-    write(stdin.buffer, "$me\ngitlab.com\n$down\r$me\n$test_file\n0.5\nyes\n$down\r$down\rd\n\n")
-    t = interactive_template()
-    @test t.user == me
-    @test t.host == "gitlab.com"
-    # Not sure if the order the licenses are displayed in is consistent.
-    @test !isempty(t.license)
-    @test t.authors == me
-    @test t.dir == abspath(test_file)
-    @test t.julia_version == v"0.5.0"
-    @test t.ssh
-    # Like above, not sure which plugins this will generate.
-    @test length(t.plugins) == 2
+    @testset "Package generation" begin
+        write(stdin.buffer, "$me\n\n\r\n\n\n\n\n\nd")
+        generate_interactive(test_pkg; gitconfig=gitconfig)
+        @test isdir(joinpath(default_dir, test_pkg))
+        rm(joinpath(default_dir, test_pkg); force=true, recursive=true)
+    end
 
-    write(stdin.buffer, "$me\nd")
-    t = interactive_template(; fast=true)
-    @test t.user == me
-    @test t.host == "github.com"
-    @test t.license == "MIT"
-    @test t.authors == LibGit2.getconfig("user.name", "")
-    @test t.dir == default_dir
-    @test t.julia_version == VERSION
-    @test !t.ssh
-    @test isempty(t.plugins)
-    println()
-end
-
-@testset "Interactive package generation" begin
-    write(stdin.buffer, "$me\n\n\r\n\n\n\n\n\nd")
-    generate_interactive(test_pkg; gitconfig=gitconfig)
-    @test isdir(joinpath(default_dir, test_pkg))
-    rm(joinpath(default_dir, test_pkg); force=true, recursive=true)
+    @testset "Plugins" begin
+        include("plugins.jl")
+    end
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -13,6 +13,11 @@ end
 struct Bar <: CustomPlugin end
 # A dummy Plugin subtype.
 struct Baz <: Plugin end
+# A Documenter with extra kwargs
+struct Qux <: Documenter
+    assets::Vector{AbstractString}
+    additional_kwargs::Union{AbstractDict, NamedTuple}
+end
 
 # Various options to be passed into templates.
 const me = "christopher-dG"
@@ -93,16 +98,6 @@ write(test_file, template_text)
         @test t.user == LibGit2.getconfig("github.user", "")
     end
     @test_throws ArgumentError Template(; user=me, license="FakeLicense")
-end
-
-# TerminalMenus doesn't work quite right on Travis OSX.
-if get(ENV, "TRAVIS_OS_NAME", "") != "osx"
-    include(joinpath("interactive", "interactive.jl"))
-    @testset "Interactive plugin creation" begin
-        include(joinpath("interactive", "plugins.jl"))
-    end
-else
-    @info "Skipping tests that require TerminalMenus on OSX"
 end
 
 @testset "Show methods" begin
@@ -397,12 +392,6 @@ end
     include(joinpath("plugins", "githubpages.jl"))
 end
 
-# A Documenter with extra kwargs
-struct Qux <: Documenter
-    assets::Vector{AbstractString}
-    additional_kwargs::Union{AbstractDict, NamedTuple}
-end
-
 @testset "Documenter add kwargs" begin
     t = Template(; user=me)
     pkg_dir = joinpath(t.dir, test_pkg)
@@ -441,5 +430,7 @@ end
     warn_str = "Ignoring predefined Documenter kwargs :format from additional kwargs"
     check_kwargs(kwargs, warn_str)
 end
+
+include(joinpath("interactive", "interactive.jl"))
 
 rm(test_file)


### PR DESCRIPTION
Way back TerminalMenus.jl didn't work in Travis OSX tests, but apparently it's all good now. Also realized that using `@spawn` instead of `@async` is kind of useless.