### PR TITLE
Fix UUID to match registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "PkgTemplates"
-uuid = "19f0ff7e-bab4-11e8-074b-97459630f98a"
+uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf <chrisadegraaf@gmail.com>"]
 version = "0.3.0"
 


### PR DESCRIPTION
The difference almost murdered my brain today by loading two versions of PkgTemplates in the same session.