### PR TITLE
Update format in Documenter make script

### DIFF
--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -72,7 +72,7 @@ function gen_plugin(p::Documenter, t::Template, pkg_name::AbstractString)
 
         makedocs(;
             modules=[$pkg_name],
-            format=:html,
+            format=Documenter.HTML(),
             pages=[
                 "Home" => "index.md",
             ],


### PR DESCRIPTION
Just tried `PkgTemplates` for a new project, very cool! Building the docs gave me the following deprecation warning:

```julia
┌ Warning: `format = :html` is deprecated, use `format = Documenter.HTML()` instead.
```

With this change, probably [this test](https://github.com/invenia/PkgTemplates.jl/blob/62702da431f669f052aeb568718fcc373f00c0d2/test/tests.jl#L466) has to be updated as well. Using `Documenter v0.21.0` here.