### PR TITLE
Drop AutoHashEquals dependency, other minor updates

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,3 @@
-[[AutoHashEquals]]
-git-tree-sha1 = "45bb6705d93be619b81451bb2006b7ee5d4e4453"
-uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
-version = "0.2.0"
-
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Chris de Graaf <chrisadegraaf@gmail.com>"]
 version = "0.4.1"
 
 [deps]
-AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.7
-AutoHashEquals
 Mustache
 URIParser

--- a/src/PkgTemplates.jl
+++ b/src/PkgTemplates.jl
@@ -1,6 +1,5 @@
 module PkgTemplates
 
-using AutoHashEquals
 using Dates
 using InteractiveUtils
 using LibGit2

--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -69,19 +69,19 @@ abstract type GenericPlugin <: Plugin end
 
 function Base.show(io::IO, p::GenericPlugin)
     spc = "  "
-    println(io, "$(nameof(typeof(p))):")
+    println(io, nameof(typeof(p)), ":")
 
     cfg = if p.src === nothing
         "None"
     else
         dirname(p.src) == DEFAULTS_DIR ? "Default" : p.src
     end
-    println(io, "$spc→ Config file: $cfg")
+    println(io, spc, "→ Config file: ", cfg)
 
     n = length(p.gitignore)
     s = n == 1 ? "" : "s"
-    print(io, "$spc→ $n gitignore entrie$s")
-    n > 0 && print(io, ": $(join(map(g -> "\"$g\"", p.gitignore), ", "))")
+    print(io, spc, "→ $n gitignore entrie$s")
+    n > 0 && print(io, ": ", join(map(repr, p.gitignore), ", "))
 end
 
 """
@@ -230,7 +230,7 @@ function interactive(T::Type{<:GenericPlugin}; file::Union{AbstractString, Nothi
     if default_config_file == nothing
         print("[None]: ")
     else
-        print("[$(replace(default_config_file, homedir() => "~"))]: ")
+        print("[", replace(default_config_file, homedir() => "~"), "]: ")
     end
 
     config_file = readline()

--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -21,7 +21,7 @@ Generic plugins are plugins that add any number of patterns to the generated pac
 
 # Example
 ```julia
-@auto_hash_equals struct MyPlugin <: GenericPlugin
+struct MyPlugin <: GenericPlugin
     gitignore::Vector{AbstractString}
     src::Union{AbstractString, Nothing}
     dest::AbstractString
@@ -96,7 +96,7 @@ signature.
 
 # Example
 ```julia
-@auto_hash_equals struct MyPlugin <: CustomPlugin
+struct MyPlugin <: CustomPlugin
     gitignore::Vector{AbstractString}
     lucky::Bool
 
@@ -152,10 +152,10 @@ A `Badge` contains the data necessary to generate a Markdown badge.
 * `image::AbstractString`: URL to the image to display.
 * `link::AbstractString`: URL to go to upon clicking the badge.
 """
-@auto_hash_equals struct Badge
-    hover::AbstractString
-    image::AbstractString
-    link::AbstractString
+struct Badge
+    hover::String
+    image::String
+    link::String
 end
 
 """

--- a/src/plugins/appveyor.jl
+++ b/src/plugins/appveyor.jl
@@ -8,10 +8,10 @@ generated repositories, and an appropriate badge to the README.
 * `config_file::Union{AbstractString, Nothing}=""`: Path to a custom `.appveyor.yml`.
   If `nothing` is supplied, no file will be generated.
 """
-@auto_hash_equals struct AppVeyor <: GenericPlugin
-    gitignore::Vector{AbstractString}
-    src::Union{AbstractString, Nothing}
-    dest::AbstractString
+struct AppVeyor <: GenericPlugin
+    gitignore::Vector{String}
+    src::Union{String, Nothing}
+    dest::String
     badges::Vector{Badge}
     view::Dict{String, Any}
 

--- a/src/plugins/codecov.jl
+++ b/src/plugins/codecov.jl
@@ -9,10 +9,10 @@ to generated repositories, and an appropriate badge to the README. Also updates 
 * `config_file::Union{AbstractString, Nothing}=nothing`: Path to a custom `.codecov.yml`.
   If left unset, no file will be generated.
 """
-@auto_hash_equals struct Codecov <: GenericPlugin
-    gitignore::Vector{AbstractString}
-    src::Union{AbstractString, Nothing}
-    dest::AbstractString
+struct Codecov <: GenericPlugin
+    gitignore::Vector{String}
+    src::Union{String, Nothing}
+    dest::String
     badges::Vector{Badge}
     view::Dict{String, Any}
 

--- a/src/plugins/coveralls.jl
+++ b/src/plugins/coveralls.jl
@@ -9,10 +9,10 @@ file to generated repositories, and an appropriate badge to the README. Also upd
 * `config_file::Union{AbstractString, Nothing}=nothing`: Path to a custom `.coveralls.yml`.
   If left unset, no file will be generated.
 """
-@auto_hash_equals struct Coveralls <: GenericPlugin
-    gitignore::Vector{AbstractString}
-    src::Union{AbstractString, Nothing}
-    dest::AbstractString
+struct Coveralls <: GenericPlugin
+    gitignore::Vector{String}
+    src::Union{String, Nothing}
+    dest::String
     badges::Vector{Badge}
     view::Dict{String, Any}
 

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -109,19 +109,19 @@ end
 
 function Base.show(io::IO, p::Documenter)
     spc = "  "
-    println(io, "$(nameof(typeof(p))):")
+    println(io, nameof(typeof(p)), ":")
 
     n = length(p.assets)
     s = n == 1 ? "" : "s"
-    print(io, "$spc→ $n asset file$s")
+    print(io, spc, "→ $n asset file$s")
     if n == 0
         println(io)
     else
-        println(io, ": $(join(map(a -> replace(a, homedir() => "~"), p.assets), ", "))")
+        println(io, ": ", join(map(a -> replace(a, homedir() => "~"), p.assets), ", "))
     end
 
     n = length(p.gitignore)
     s = n == 1 ? "" : "s"
     print(io, "$spc→ $n gitignore entrie$s")
-    n > 0 && print(io, ": $(join(map(g -> "\"$g\"", p.gitignore), ", "))")
+    n > 0 && print(io, ": ", join(map(repr, p.gitignore), ", "))
 end

--- a/src/plugins/githubpages.jl
+++ b/src/plugins/githubpages.jl
@@ -13,9 +13,9 @@ adds appropriate badges to the README, and updates the `.gitignore` accordingly.
     configuration (see
     [here](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#SSH-Deploy-Keys-1)).
 """
-@auto_hash_equals struct GitHubPages <: Documenter
-    gitignore::Vector{AbstractString}
-    assets::Vector{AbstractString}
+struct GitHubPages <: Documenter
+    gitignore::Vector{String}
+    assets::Vector{String}
 
     function GitHubPages(; assets::Vector{<:AbstractString}=String[])
         for file in assets

--- a/src/plugins/gitlabci.jl
+++ b/src/plugins/gitlabci.jl
@@ -61,7 +61,7 @@ function interactive(::Type{GitLabCI})
     default_config_file = joinpath(DEFAULTS_DIR, "gitlab-ci.yml")
 
     print("$name: Enter the config template filename (\"None\" for no file) ")
-    print("[$default_config_file]: ")
+    print("[", replace(default_config_file, homedir() => "~"), "]: ")
     config_file = readline()
     kwargs[:config_file] = if uppercase(config_file) == "NONE"
         nothing

--- a/src/plugins/gitlabci.jl
+++ b/src/plugins/gitlabci.jl
@@ -10,10 +10,10 @@ generated repositories, and appropriate badge(s) to the README.
 * `coverage::Bool=true`: Whether or not GitLab CI's built-in code coverage analysis should
   be enabled.
 """
-@auto_hash_equals struct GitLabCI <: GenericPlugin
-    gitignore::Vector{AbstractString}
-    src::Union{AbstractString, Nothing}
-    dest::AbstractString
+struct GitLabCI <: GenericPlugin
+    gitignore::Vector{String}
+    src::Union{String, Nothing}
+    dest::String
     badges::Vector{Badge}
     view::Dict{String, Any}
 

--- a/src/plugins/travisci.jl
+++ b/src/plugins/travisci.jl
@@ -8,10 +8,10 @@ generated repositories, and an appropriate badge to the README.
 * `config_file::Union{AbstractString, Nothing}=""`: Path to a custom `.travis.yml`.
   If `nothing` is supplied, no file will be generated.
 """
-@auto_hash_equals struct TravisCI <: GenericPlugin
-    gitignore::Vector{AbstractString}
-    src::Union{AbstractString, Nothing}
-    dest::AbstractString
+struct TravisCI <: GenericPlugin
+    gitignore::Vector{String}
+    src::Union{String, Nothing}
+    dest::String
     badges::Vector{Badge}
     view::Dict{String, Any}
 

--- a/src/template.jl
+++ b/src/template.jl
@@ -26,16 +26,16 @@ create a template, you can use [`interactive_template`](@ref) instead.
 * `manifest::Bool=false`: Whether or not to commit the `Manifest.toml`.
 * `plugins::Vector{<:Plugin}=Plugin[]`: A list of `Plugin`s that the package will include.
 """
-@auto_hash_equals struct Template
-    user::AbstractString
-    host::AbstractString
-    license::AbstractString
-    authors::AbstractString
-    dir::AbstractString
+struct Template
+    user::String
+    host::String
+    license::String
+    authors::String
+    dir::String
     julia_version::VersionNumber
     ssh::Bool
     manifest::Bool
-    plugins::Dict{DataType, Plugin}
+    plugins::Dict{DataType, <:Plugin}
 
     function Template(;
         user::AbstractString="",

--- a/src/template.jl
+++ b/src/template.jl
@@ -88,26 +88,26 @@ struct Template
 end
 
 function Base.show(io::IO, t::Template)
-    maybe(s::AbstractString) = isempty(string(s)) ? "None" : string(s)
+    maybe(s::String) = isempty(s) ? "None" : s
     spc = "  "
 
     println(io, "Template:")
-    println(io, "$spc→ User: $(maybe(t.user))")
-    println(io, "$spc→ Host: $(maybe(t.host))")
+    println(io, spc, "→ User: ", maybe(t.user))
+    println(io, spc, "→ Host: ", maybe(t.host))
 
-    print(io, "$spc→ License: ")
+    print(io, spc, "→ License: ")
     if isempty(t.license)
         println(io, "None")
     else
-        println(io, "$(t.license) ($(t.authors) $(year(today())))")
+        println(io, t.license, " ($(t.authors) ", year(today()), ")")
     end
 
-    println(io, "$spc→ Package directory: $(replace(maybe(t.dir), homedir() => "~"))")
-    println(io, "$spc→ Minimum Julia version: v$(version_floor(t.julia_version))")
-    println(io, "$spc→ SSH remote: $(t.ssh ? "Yes" : "No")")
-    println(io, "$spc→ Commit Manifest.toml: $(t.manifest ? "Yes" : "No")")
+    println(io, spc, "→ Package directory: ", replace(maybe(t.dir), homedir() => "~"))
+    println(io, spc, "→ Minimum Julia version: v", version_floor(t.julia_version))
+    println(io, spc, "→ SSH remote: ", t.ssh ? "Yes" : "No")
+    println(io, spc, "→ Commit Manifest.toml: ", t.manifest ? "Yes" : "No")
 
-    print(io, "$spc→ Plugins:")
+    print(io, spc, "→ Plugins:")
     if isempty(t.plugins)
         print(io, " None")
     else
@@ -115,7 +115,7 @@ function Base.show(io::IO, t::Template)
             println(io)
             buf = IOBuffer()
             show(buf, plugin)
-            print(io, "$(spc^2)• ")
+            print(io, spc^2, "• ")
             print(io, join(split(String(take!(buf)), "\n"), "\n$(spc^2)"))
         end
     end
@@ -135,7 +135,7 @@ function interactive_template(; git::Bool=true, fast::Bool=false)
     kwargs = Dict{Symbol, Any}()
 
     default_user = LibGit2.getconfig("github.user", "")
-    print("Username [$(isempty(default_user) ? "REQUIRED" : default_user)]: ")
+    print("Username [", isempty(default_user) ? "REQUIRED" : default_user, "]: ")
     user = readline()
     kwargs[:user] = if !isempty(user)
         user
@@ -192,7 +192,7 @@ function interactive_template(; git::Bool=true, fast::Bool=false)
         VERSION
     else
         default_julia_version = VERSION
-        print("Mminimum Julia version [$(version_floor(default_julia_version))]: ")
+        print("Minimum Julia version [", version_floor(default_julia_version), "]: ")
         julia_version = readline()
         isempty(julia_version) ? default_julia_version : VersionNumber(julia_version)
     end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -85,11 +85,8 @@ write(test_file, template_text)
         user=me,
         plugins = [GitHubPages(), TravisCI(), AppVeyor(), Codecov(), Coveralls()],
     )
-    @test Set(keys(t.plugins)) == Set(
+    @test Set(keys(t.plugins)) == Set(map(typeof, values(t.plugins))) == Set(
         [GitHubPages, TravisCI, AppVeyor, Codecov, Coveralls]
-    )
-    @test Set(values(t.plugins)) == Set(
-        [GitHubPages(), TravisCI(), AppVeyor(), Codecov(), Coveralls()]
     )
 
     # Duplicate plugins should warn.


### PR DESCRIPTION
I don't precisely remember why we needed AutoHashEquals (I think maybe Julia v0.x didn't implement `hash`, which `Dict` keys require, for new structs), but one test did still depend on it. Regardless, it's not needed anymore.

Other changes:
- Make struct fields concrete (mostly `AbstractString` -> `String`)
- Replace some big interpolated expressions with the varargs form of `print` 
