### PR TITLE
Fix code loading in documentation generation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,6 +23,7 @@ run(`git config --global user.email "travis@c.i"`)
 run(`git config --global github.user "travis"`)
 using Pkg
 Pkg.activate(mktempdir())
+# This code gets run in docs/build/, so this path evaluates to the repo root.
 Pkg.add(PackageSpec(path=dirname(dirname(pwd()))))
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,6 +23,7 @@ run(`git config --global user.email "travis@c.i"`)
 run(`git config --global github.user "travis"`)
 using Pkg
 Pkg.activate(mktempdir())
+Pkg.add(PackageSpec(path=dirname(dirname(pwd()))))
 ```
 
 The simplest template requires no arguments.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,9 +18,10 @@ pkg> add PkgTemplates
 ## Usage
 
 ```@setup usage
-run(`git config --global user.name "Travis"`)
-run(`git config --global user.email "travis@c.i"`)
-run(`git config --global github.user "travis"`)
+using LibGit2: getconfig
+isempty(getconfig("user.name", "")) && run(`git config --global user.name "Travis"`)
+isempty(getconfig("user.email", "")) && run(`git config --global user.email "travis@c.i"`)
+isempty(getconfig("github.user", "")) && run(`git config --global github.user "travis"`)
 using Pkg
 Pkg.activate(mktempdir())
 # This code gets run in docs/build/, so this path evaluates to the repo root.


### PR DESCRIPTION
Closes #49 

The examples run in a new environment since they create new packages, but PkgTemplates wasn't installed in it. 