### PR TITLE
Use "dev" instead of "latest" to link GitHub pages

### DIFF
--- a/src/plugins/githubpages.jl
+++ b/src/plugins/githubpages.jl
@@ -36,9 +36,9 @@ function badges(::GitHubPages, user::AbstractString, pkg_name::AbstractString)
             "https://$user.github.io/$pkg_name.jl/stable"
         )),
         format(Badge(
-            "Latest",
-            "https://img.shields.io/badge/docs-latest-blue.svg",
-            "https://$user.github.io/$pkg_name.jl/latest"
+            "Dev",
+            "https://img.shields.io/badge/docs-dev-blue.svg",
+            "https://$user.github.io/$pkg_name.jl/dev"
         )),
     ]
 end

--- a/test/plugins/githubpages.jl
+++ b/test/plugins/githubpages.jl
@@ -15,7 +15,7 @@ pkg_dir = joinpath(t.dir, test_pkg)
         p = GitHubPages()
         @test badges(p, me, test_pkg) ==  [
             "[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://$me.github.io/$test_pkg.jl/stable)"
-            "[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://$me.github.io/$test_pkg.jl/latest)"
+            "[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://$me.github.io/$test_pkg.jl/dev)"
         ]
     end
 


### PR DESCRIPTION
It seems Documenter.jl changed the setting:
https://juliadocs.github.io/Documenter.jl/v0.21/lib/public/#Documenter.deploydocs