### PR TITLE
Revert "Use METADATA-compatible UUIDs"

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -18,11 +18,6 @@ function generate(
         # Create the directory with some boilerplate inside.
         Pkg.generate(pkg_dir)
 
-        # Replace the UUID with something that's compatible with METADATA.
-        project = joinpath(pkg_dir, "Project.toml")
-        uuid = string(Pkg.METADATA_compatible_uuid(pkg))
-        write(project, replace(read(project, String), r"uuid = .*" => "uuid = \"$uuid\""))
-
         if git
             # Initialize the repo.
             repo = LibGit2.init(pkg_dir)


### PR DESCRIPTION
This partially reverts commit 8a1b65a34a43ee80ae868ec4c2775a716f9b8352 from #56.

see: https://discourse.julialang.org/t/22677/22