### PR TITLE
Add Drone CI plugin

### DIFF
--- a/defaults/drone.yml
+++ b/defaults/drone.yml
@@ -1,0 +1,29 @@
+---
+kind: pipeline
+name: linux - arm - Julia {{VERSION}}
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: julia:{{VERSION}}
+  commands:
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
+
+---
+kind: pipeline
+name: linux - arm64 - Julia {{VERSION}}
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:{{VERSION}}
+  commands:
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
+
+...

--- a/src/PkgTemplates.jl
+++ b/src/PkgTemplates.jl
@@ -24,6 +24,7 @@ export
     TravisCI,
     GitLabCI,
     CirrusCI,
+    DroneCI,
     Codecov,
     Coveralls,
     Citation
@@ -45,6 +46,7 @@ include(joinpath("plugins", "codecov.jl"))
 include(joinpath("plugins", "travisci.jl"))
 include(joinpath("plugins", "gitlabci.jl"))
 include(joinpath("plugins", "cirrusci.jl"))
+include(joinpath("plugins", "droneci.jl"))
 include(joinpath("plugins", "githubpages.jl"))
 include(joinpath("plugins", "gitlabpages.jl"))
 include(joinpath("plugins", "citation.jl"))

--- a/src/plugins/droneci.jl
+++ b/src/plugins/droneci.jl
@@ -1,0 +1,45 @@
+"""
+    DroneCI(; config_file::Union{AbstractString, Nothing}="") -> DroneCI
+
+Add `DroneCI` to a template's plugins to add a `.drone.yml` configuration file to
+generated repositories, and an appropriate badge to the README. The default configuration
+file supports Linux on ARM32 and ARM64.
+
+# Keyword Arguments
+* `config_file::Union{AbstractString, Nothing}=""`: Path to a custom `.drone.yml`.
+  If `nothing` is supplied, no file will be generated.
+"""
+struct DroneCI <: GenericPlugin
+    gitignore::Vector{String}
+    src::Union{String, Nothing}
+    dest::String
+    badges::Vector{Badge}
+    view::Dict{String, Any}
+
+    function DroneCI(; config_file::Union{AbstractString, Nothing}="")
+        if config_file !== nothing
+            config_file = if isempty(config_file)
+                joinpath(DEFAULTS_DIR, "drone.yml")
+            elseif isfile(config_file)
+                abspath(config_file)
+            else
+                throw(ArgumentError("File $(abspath(config_file)) does not exist"))
+            end
+        end
+        return new(
+            [],
+            config_file,
+            ".drone.yml",
+            [
+                Badge(
+                    "Build Status",
+                    "https://cloud.drone.io/api/badges/{{USER}}/{{PKGNAME}}.jl/status.svg",
+                    "https://cloud.drone.io/{{USER}}/{{PKGNAME}}.jl",
+                ),
+            ],
+            Dict{String, Any}(),
+        )
+    end
+end
+
+interactive(::Type{DroneCI}) = interactive(DroneCI; file="drone.yml")

--- a/test/plugins/droneci.jl
+++ b/test/plugins/droneci.jl
@@ -1,0 +1,41 @@
+t = Template(; user=me)
+pkg_dir = joinpath(t.dir, test_pkg)
+
+@testset "DroneCI" begin
+    @testset "Plugin creation" begin
+        p = DroneCI()
+        @test isempty(p.gitignore)
+        @test p.src == joinpath(DEFAULTS_DIR, "drone.yml")
+        @test p.dest == ".drone.yml"
+        @test p.badges == [
+            Badge(
+                "Build Status",
+                "https://cloud.drone.io/api/badges/{{USER}}/{{PKGNAME}}.jl/status.svg",
+                "https://cloud.drone.io/{{USER}}/{{PKGNAME}}.jl",
+            ),
+        ]
+        @test isempty(p.view)
+        p = DroneCI(; config_file=nothing)
+        @test p.src === nothing
+        p = DroneCI(; config_file=test_file)
+        @test p.src == test_file
+        @test_throws ArgumentError DroneCI(; config_file=fake_path)
+    end
+
+    @testset "Badge generation" begin
+        p = DroneCI()
+        @test badges(p, me, test_pkg) == ["[![Build Status](https://cloud.drone.io/api/badges/$me/$test_pkg.jl/status.svg)](https://cloud.drone.io/$me/$test_pkg.jl)"]
+    end
+
+    @testset "File generation" begin
+        # Without a coverage plugin in the template, there should be no coverage step.
+        p = DroneCI()
+        @test gen_plugin(p, t, test_pkg) == [".drone.yml"]
+        @test isfile(joinpath(pkg_dir, ".drone.yml"))
+        drone = read(joinpath(pkg_dir, ".drone.yml"), String)
+        @test !occursin("coverage_script", drone)
+        rm(joinpath(pkg_dir, ".drone.yml"))
+    end
+end
+
+rm(pkg_dir; recursive=true)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -441,6 +441,7 @@ end
     include(joinpath("plugins", "appveyor.jl"))
     include(joinpath("plugins", "gitlabci.jl"))
     include(joinpath("plugins", "cirrusci.jl"))
+    include(joinpath("plugins", "droneci.jl"))
     include(joinpath("plugins", "codecov.jl"))
     include(joinpath("plugins", "coveralls.jl"))
     include(joinpath("plugins", "githubpages.jl"))


### PR DESCRIPTION
Fix #93.  I went with the easiest solution of just generating `.drone.yml` without the Jsonnet file.

I hope I didn't mess things up, I mostly just copied whatever was there for Cirrus and replace "cirrus" ->  "drone" :stuck_out_tongue: 