### PR TITLE
"Uncomment the following line to override the default script"

### DIFF
--- a/defaults/travis.yml
+++ b/defaults/travis.yml
@@ -12,6 +12,8 @@ matrix:
   fast_finish: true
 notifications:
   email: false
+# Uncomment the following line to override the default script:
+# script: julia -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 {{#COVERAGE}}
 after_success:
 {{#CODECOV}}


### PR DESCRIPTION
The default Travis `script` for Julia projects is very good.

However, it is common for users to make slight modifications to the default `script`.

For example, I often find myself needing to disable inlining during the package tests in order to get accurate code coverage. This is very simple - I just need to add the option `--inline=no` to the default `script`.

Currently, if a user wants to make a modification to the default `script`, they need to reference the Travis documentation (https://docs.travis-ci.com/user/languages/julia/#default-build-and-test-script) in order to determine what the default `script` is.

I figure that we can make life easier by added a commented-out version of the default `script` to our `.travis.yml` file.

This won't have any effect by default, since it only adds two lines, and both of them are commented out. But if a user later wants to modify the default `script`, it is really easy because the default is right there in the file.