### PR TITLE
The default initial version number should be 1.0.0

### DIFF
--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -108,7 +108,7 @@ function hook(p::Documenter, t::Template, pkg_dir::AbstractString)
 
     make = render_file(p.make_jl, combined_view(p, t, pkg), tags(p))
     gen_file(joinpath(docs_dir, "make.jl"), make)
-    
+
     index = render_file(p.index_md, combined_view(p, t, pkg), tags(p))
     gen_file(joinpath(docs_dir, "src", "index.md"), index)
 
@@ -255,7 +255,7 @@ To see why, it might help to see the template file in its entirety:
 	author  = {<<&AUTHORS>>},
 	title   = {<<&PKG>>.jl},
 	url     = {<<&URL>>},
-	version = {v0.1.0},
+	version = {v1.0.0},
 	year    = {<<&YEAR>>},
 	month   = {<<&MONTH>>}
 }

--- a/src/plugins/project_file.jl
+++ b/src/plugins/project_file.jl
@@ -1,5 +1,5 @@
 """
-    ProjectFile(; version=v"0.1.0")
+    ProjectFile(; version=v"1.0.0")
 
 Creates a `Project.toml`.
 
@@ -7,7 +7,7 @@ Creates a `Project.toml`.
 - `version::VersionNumber`: The initial version of created packages.
 """
 @with_kw_noshow struct ProjectFile <: Plugin
-    version::VersionNumber = v"0.1.0"
+    version::VersionNumber = v"1.0.0"
 end
 
 # Other plugins like Tests will modify this file.

--- a/templates/CITATION.bib
+++ b/templates/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {<<&AUTHORS>>},
 	title   = {<<&PKG>>.jl},
 	url     = {<<&URL>>},
-	version = {v0.1.0},
+	version = {v1.0.0},
 	year    = {<<&YEAR>>},
 	month   = {<<&MONTH>>}
 }

--- a/test/fixtures/AllPlugins/CITATION.bib
+++ b/test/fixtures/AllPlugins/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {tester},
 	title   = {AllPlugins.jl},
 	url     = {https://github.com/tester/AllPlugins.jl},
-	version = {v0.1.0},
+	version = {v1.0.0},
 	year    = {2019},
 	month   = {8}
 }

--- a/test/fixtures/AllPlugins/Project.toml
+++ b/test/fixtures/AllPlugins/Project.toml
@@ -1,7 +1,7 @@
 name = "AllPlugins"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
 authors = ["tester"]
-version = "0.1.0"
+version = "1.0.0"
 
 [compat]
 julia = "1"

--- a/test/fixtures/Basic/Project.toml
+++ b/test/fixtures/Basic/Project.toml
@@ -1,7 +1,7 @@
 name = "Basic"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
 authors = ["tester"]
-version = "0.1.0"
+version = "1.0.0"
 
 [compat]
 julia = "1"

--- a/test/fixtures/DocumenterGitHubActions/Project.toml
+++ b/test/fixtures/DocumenterGitHubActions/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterGitHubActions"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
 authors = ["tester"]
-version = "0.1.0"
+version = "1.0.0"
 
 [compat]
 julia = "1"

--- a/test/fixtures/DocumenterTravis/Project.toml
+++ b/test/fixtures/DocumenterTravis/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterTravis"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
 authors = ["tester"]
-version = "0.1.0"
+version = "1.0.0"
 
 [compat]
 julia = "1"

--- a/test/fixtures/WackyOptions/CITATION.bib
+++ b/test/fixtures/WackyOptions/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {tester},
 	title   = {WackyOptions.jl},
 	url     = {https://github.com/tester/WackyOptions.jl},
-	version = {v0.1.0},
+	version = {v1.0.0},
 	year    = {2019},
 	month   = {8}
 }

--- a/test/show.jl
+++ b/test/show.jl
@@ -39,7 +39,7 @@ const LICENSES_DIR = joinpath(TEMPLATES_DIR, "licenses")
                   path: "$(joinpath(LICENSES_DIR, "MIT"))"
                   destination: "LICENSE"
                 ProjectFile:
-                  version: v"0.1.0"
+                  version: v"1.0.0"
                 Readme:
                   file: "$(joinpath(TEMPLATES_DIR, "README.md"))"
                   destination: "README.md"


### PR DESCRIPTION
Currently, the default initial version number of a newly created package is `0.1.0`.

This pull request changes the default initial version number to `1.0.0`.

## Rationale

There has been a lot of confusion in the Julia community about the behavior of semver in pre-`1.0` versions.

I think that we should encourage people to just start numbering the versions of their packages at `1.0.0`.

Of course, it is extremely easy for a user to select their own initial version number simply by using the `ProjectFile` plugin, i.e.:
```julia
ProjectFile(; version=v"3.4.5")
```

So I don't think it is a huge burden for a user to change the initial version number.

But I think that we should encourage good default values, and I think `1.0.0` is a good default value for the initial version number.