### PR TITLE
Allow failures for Windows on 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ julia:
 before_script:
   - git config --global user.name Tester
   - git config --global user.email te@st.er
+script: travis_wait julia --project -e 'using Pkg; Pkg.test(; coverage=true)'
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
FFTW, is required by something in ReferenceTests, and its build seems to either hang or just take a long time on Windows in Julia 1.0. 
Example: https://travis-ci.org/invenia/PkgTemplates.jl/jobs/609854008