### PR TITLE
Correct verision string to indicate this is unreleased

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.0"
+version = "0.7.0-DEV"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
As per
https://white.ucc.asn.au/2019/09/28/Continuous-Delivery-For-Julia-Packages.html#what-if-i-dont-want-to-release-right-now--dev-versions

and inline with how Julia itself uses `-DEV`