### PR TITLE
Add deprecations of old exports

### DIFF
--- a/src/PkgTemplates.jl
+++ b/src/PkgTemplates.jl
@@ -42,6 +42,7 @@ abstract type Plugin end
 include("template.jl")
 include("plugin.jl")
 include("show.jl")
+include("deprecated.jl")
 
 # Run some function with a project activated at the given path.
 function with_project(f::Function, path::AbstractString)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,5 @@
+@deprecate generate(t::Template, pkg::AbstractString) t(pkg)
+@deprecate generate(pkg::AbstractString, t::Template) t(pkg)
+@deprecate interactive_template() Template(; interactive=true)
+@deprecate generate_interactive(pkg::AbstractString) Template(; interactive=true)(pkg)
+@deprecate GitHubPages(; kwargs...) Documenter{TravisCI}(; kwargs...)


### PR DESCRIPTION
This should take care of the most common undefined methods that people will run into.
The `interactive` ones don't actually have an implementation beneath them yet, but they don't throw errors.

Unrelated, I think I can avoid changing the reference test manifests by mocking `Pkg.add(::PackageSpec)`, but it only worked on 1.3. Eventually these files won't need constant updates.