### PR TITLE
Fix broken GH Actions badge

### DIFF
--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -67,7 +67,7 @@ tags(::GitHubActions) = "<<", ">>"
 badges(p::GitHubActions) = Badge(
     "Build Status",
     "https://github.com/{{{USER}}}/{{{PKG}}}.jl/workflows/CI/badge.svg",
-    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/actions"
+    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/actions",
 )
 
 function view(p::GitHubActions, t::Template, pkg::AbstractString)

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -66,8 +66,8 @@ tags(::GitHubActions) = "<<", ">>"
 
 badges(p::GitHubActions) = Badge(
     "Build Status",
-    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/actions",
     "https://github.com/{{{USER}}}/{{{PKG}}}.jl/workflows/CI/badge.svg",
+    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/actions"
 )
 
 function view(p::GitHubActions, t::Template, pkg::AbstractString)


### PR DESCRIPTION
the link and image urls are backwards.