### PR TITLE
Merge `matrix:` and `jobs:` sections in .travis.yml

### DIFF
--- a/defaults/travis.yml
+++ b/defaults/travis.yml
@@ -6,10 +6,6 @@ os:
 julia:
   - {{VERSION}}
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
 notifications:
   email: false
 {{#COVERAGE}}
@@ -21,8 +17,11 @@ after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 {{/COVERALLS}}
 {{/COVERAGE}}
-{{#DOCUMENTER}}
 jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
+{{#DOCUMENTER}}
   include:
     - stage: Documentation
       julia: {{VERSION}}


### PR DESCRIPTION
* These are aliases in travis, and defining them twice causes one to
  overwrite the other.  In this case, `matrix` was overwriting `jobs`,
  which caused `Documentation` not to run.

Fixes #132

Note: this targets the current release branch, not master.  It's already been fixed on master, so this is meant as a stop-gap fix until master is release.