### PR TITLE
Switch to using GitLab CI extends

### DIFF
--- a/templates/gitlab-ci.yml
+++ b/templates/gitlab-ci.yml
@@ -1,30 +1,30 @@
-.definitions:
-  script: &script
-    script:
-      - |
-        julia --project=@. -e '
-          using Pkg
-          Pkg.build()
-          Pkg.test({{#HAS_COVERAGE}}coverage=true{{/HAS_COVERAGE}})'
+.script:
+  script:
+    - |
+      julia --project=@. -e '
+        using Pkg
+        Pkg.build()
+        Pkg.test({{#HAS_COVERAGE}}coverage=true{{/HAS_COVERAGE}})'
 {{#HAS_COVERAGE}}
-  coverage: &coverage
-    coverage: /Test coverage (\d+\.\d+%)/
-    after_script:
-      - |
-        julia -e '
-          using Pkg
-          Pkg.add("Coverage")
-          using Coverage
-          c, t = get_summary(process_folder())
-          using Printf
-          @printf "Test coverage %.2f%%\n" 100c / t'
+.coverage:
+  coverage: /Test coverage (\d+\.\d+%)/
+  after_script:
+    - |
+      julia -e '
+        using Pkg
+        Pkg.add("Coverage")
+        using Coverage
+        c, t = get_summary(process_folder())
+        using Printf
+        @printf "Test coverage %.2f%%\n" 100c / t'
 {{/HAS_COVERAGE}}
 {{#VERSIONS}}
 Julia {{{.}}}:
   image: julia:{{{.}}}
-  <<: *script
+  extends:
+    - .script
 {{#HAS_COVERAGE}}
-  <<: *coverage
+    - .coverage
 {{/HAS_COVERAGE}}
 {{/VERSIONS}}
 {{#HAS_DOCUMENTER}}

--- a/test/fixtures/AllPlugins/.gitlab-ci.yml
+++ b/test/fixtures/AllPlugins/.gitlab-ci.yml
@@ -1,27 +1,28 @@
-.definitions:
-  script: &script
-    script:
-      - |
-        julia --project=@. -e '
-          using Pkg
-          Pkg.build()
-          Pkg.test(coverage=true)'
-  coverage: &coverage
-    coverage: /Test coverage (\d+\.\d+%)/
-    after_script:
-      - |
-        julia -e '
-          using Pkg
-          Pkg.add("Coverage")
-          using Coverage
-          c, t = get_summary(process_folder())
-          using Printf
-          @printf "Test coverage %.2f%%\n" 100c / t'
+.script:
+  script:
+    - |
+      julia --project=@. -e '
+        using Pkg
+        Pkg.build()
+        Pkg.test(coverage=true)'
+.coverage:
+  coverage: /Test coverage (\d+\.\d+%)/
+  after_script:
+    - |
+      julia -e '
+        using Pkg
+        Pkg.add("Coverage")
+        using Coverage
+        c, t = get_summary(process_folder())
+        using Printf
+        @printf "Test coverage %.2f%%\n" 100c / t'
 Julia 1.0:
   image: julia:1.0
-  <<: *script
-  <<: *coverage
+  extends:
+    - .script
+    - .coverage
 Julia 1.3:
   image: julia:1.3
-  <<: *script
-  <<: *coverage
+  extends:
+    - .script
+    - .coverage

--- a/test/fixtures/WackyOptions/.gitlab-ci.yml
+++ b/test/fixtures/WackyOptions/.gitlab-ci.yml
@@ -1,17 +1,18 @@
-.definitions:
-  script: &script
-    script:
-      - |
-        julia --project=@. -e '
-          using Pkg
-          Pkg.build()
-          Pkg.test()'
+.script:
+  script:
+    - |
+      julia --project=@. -e '
+        using Pkg
+        Pkg.build()
+        Pkg.test()'
 Julia 0.6:
   image: julia:0.6
-  <<: *script
+  extends:
+    - .script
 Julia 1.2:
   image: julia:1.2
-  <<: *script
+  extends:
+    - .script
 pages:
   image: julia:1.2
   stage: deploy


### PR DESCRIPTION
Use GitLab CI's [`extends`](https://docs.gitlab.com/ee/ci/yaml/#extends) instead of YAML anchors. The `extends` is a bit more flexible and the syntax is a bit cleaner.

Note this change will conflict with #131.