### PR TITLE
add env for github actions docs building

### DIFF
--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -66,4 +66,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          GKSwstype: "100"
   <</HAS_DOCUMENTER>>


### PR DESCRIPTION
This adds an environemnt variable to the github actions ci documenter build. This makes sure that if a user is trying to plot something you avoid getting [errors like this](https://github.com/JuliaPlots/Plots.jl/issues/1182).