### PR TITLE
Git: Allow setting custom user.name and user.email

### DIFF
--- a/src/PkgTemplates.jl
+++ b/src/PkgTemplates.jl
@@ -3,7 +3,7 @@ module PkgTemplates
 using Base: active_project, contractuser
 
 using Dates: month, today, year
-using LibGit2: LibGit2, GitRemote, GitRepo
+using LibGit2: LibGit2, GitConfig, GitRemote, GitRepo
 using Pkg: Pkg, TOML, PackageSpec
 using UUIDs: uuid4
 

--- a/test/git.jl
+++ b/test/git.jl
@@ -35,6 +35,16 @@
         end
     end
 
+    @testset "With custom name/email" begin
+        t = tpl(; plugins=[Git(; name="me", email="a@b.c")])
+        with_pkg(t) do pkg
+            LibGit2.with(GitRepo(joinpath(t.dir, pkg))) do repo
+                @test LibGit2.getconfig(repo, "user.name", "") == "me"
+                @test LibGit2.getconfig(repo, "user.email", "") == "a@b.c"
+            end
+        end
+    end
+
     @testset "Adds version to commit message" begin
         # We're careful to avoid a Pkg.update as it triggers Cassette#130.
         t = tpl(; disable_defaults=[Tests], plugins=[Git()])

--- a/test/show.jl
+++ b/test/show.jl
@@ -27,6 +27,8 @@ const LICENSES_DIR = joinpath(TEMPLATES_DIR, "licenses")
                   cron: "0 0 * * *"
                 Git:
                   ignore: String[]
+                  name: nothing
+                  email: nothing
                   ssh: false
                   manifest: false
                   gpgsign: false


### PR DESCRIPTION
Closes #149 

Now no global Git configuration is strictly required via `Template(; plugins=[Git(; name="me", email="a@b.c")])`