### PR TITLE
Rename BasicPlugin -> FilePlugin

### DIFF
--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -44,7 +44,7 @@ $EXTRA_VERSIONS_DOC
     If using coverage plugins, don't forget to manually add your API tokens as secrets,
     as described [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets).
 """
-@with_kw_noshow struct GitHubActions <: BasicPlugin
+@with_kw_noshow struct GitHubActions <: FilePugin
     file::String = default_file("github", "workflows", "ci.yml")
     destination::String = "ci.yml"
     linux::Bool = true
@@ -116,7 +116,7 @@ Integrates your packages with [Travis CI](https://travis-ci.com).
   Another code coverage plugin such as [`Codecov`](@ref) must also be included.
 $EXTRA_VERSIONS_DOC
 """
-@with_kw_noshow struct TravisCI <: BasicPlugin
+@with_kw_noshow struct TravisCI <: FilePugin
     file::String = default_file("travis.yml")
     linux::Bool = true
     osx::Bool = true
@@ -188,7 +188,7 @@ via [AppVeyor.jl](https://github.com/JuliaCI/Appveyor.jl).
   [`Codecov`](@ref) must also be included.
 $EXTRA_VERSIONS_DOC
 """
-@with_kw_noshow struct AppVeyor <: BasicPlugin
+@with_kw_noshow struct AppVeyor <: FilePugin
     file::String = default_file("appveyor.yml")
     x86::Bool = false
     coverage::Bool = true
@@ -244,7 +244,7 @@ $EXTRA_VERSIONS_DOC
     Code coverage submission from Cirrus CI is not yet supported by
     [Coverage.jl](https://github.com/JuliaCI/Coverage.jl).
 """
-@with_kw_noshow struct CirrusCI <: BasicPlugin
+@with_kw_noshow struct CirrusCI <: FilePugin
     file::String = default_file("cirrus.yml")
     image::String = "freebsd-12-0-release-amd64"
     coverage::Bool = true
@@ -293,7 +293,7 @@ See [`Documenter`](@ref) for more information.
 !!! note
     Nightly Julia is not supported.
 """
-@with_kw_noshow struct GitLabCI <: BasicPlugin
+@with_kw_noshow struct GitLabCI <: FilePugin
     file::String = default_file("gitlab-ci.yml")
     coverage::Bool = true
     # Nightly has no Docker image.
@@ -352,7 +352,7 @@ $EXTRA_VERSIONS_DOC
 !!! note
     Nightly Julia is not supported.
 """
-@with_kw_noshow struct DroneCI <: BasicPlugin
+@with_kw_noshow struct DroneCI <: FilePugin
     file::String = default_file("drone.star")
     destination::String = ".drone.star"
     amd64::Bool = true

--- a/src/plugins/citation.jl
+++ b/src/plugins/citation.jl
@@ -7,7 +7,7 @@ Creates a `CITATION.bib` file for citing package repositories.
 - `file::AbstractString`: Template file for `CITATION.bib`.
 - `readme::Bool`: Whether or not to include a section about citing in the README.
 """
-@with_kw_noshow struct Citation <: BasicPlugin
+@with_kw_noshow struct Citation <: FilePugin
     file::String = default_file("CITATION.bib")
     readme::Bool = false
 end

--- a/src/plugins/compat_helper.jl
+++ b/src/plugins/compat_helper.jl
@@ -13,7 +13,7 @@ Integrates your packages with [CompatHelper](https://github.com/bcbi/CompatHelpe
   relative to `.github/workflows`.
 - `cron::AbstractString`: Cron expression for the schedule interval.
 """
-@with_kw_noshow struct CompatHelper <: BasicPlugin
+@with_kw_noshow struct CompatHelper <: FilePugin
     file::String = default_file("github", "workflows", "CompatHelper.yml")
     destination::String = "CompatHelper.yml"
     cron::String = "0 0 * * *"

--- a/src/plugins/coverage.jl
+++ b/src/plugins/coverage.jl
@@ -9,7 +9,7 @@ Sets up code coverage submission from CI to [Codecov](https://codecov.io).
 - `file::Union{AbstractString, Nothing}`: Template file for `.codecov.yml`,
   or `nothing` to create no file.
 """
-@with_kw_noshow struct Codecov <: BasicPlugin
+@with_kw_noshow struct Codecov <: FilePugin
     file::Union{String, Nothing} = nothing
 end
 
@@ -31,7 +31,7 @@ Sets up code coverage submission from CI to [Coveralls](https://coveralls.io).
 - `file::Union{AbstractString, Nothing}`: Template file for `.coveralls.yml`,
   or `nothing` to create no file.
 """
-@with_kw_noshow struct Coveralls <: BasicPlugin
+@with_kw_noshow struct Coveralls <: FilePugin
     file::Union{String, Nothing} = nothing
 end
 

--- a/src/plugins/license.jl
+++ b/src/plugins/license.jl
@@ -12,7 +12,7 @@ Creates a license file.
 - `destination::AbstractString`: File destination, relative to the repository root.
   For example, `"LICENSE.md"` might be desired.
 """
-struct License <: BasicPlugin
+struct License <: FilePugin
     path::String
     destination::String
 end

--- a/src/plugins/readme.jl
+++ b/src/plugins/readme.jl
@@ -13,7 +13,7 @@ Creates a `README` file that contains badges for other included plugins.
   For example, values of `"README"` or `"README.rst"` might be desired.
 - `inline_badges::Bool`: Whether or not to put the badges on the same line as the package name.
 """
-@with_kw_noshow struct Readme <: BasicPlugin
+@with_kw_noshow struct Readme <: FilePugin
     file::String = default_file("README.md")
     destination::String = "README.md"
     inline_badges::Bool = false

--- a/src/plugins/src_dir.jl
+++ b/src/plugins/src_dir.jl
@@ -6,7 +6,7 @@ Creates a module entrypoint.
 ## Keyword Arguments
 - `file::AbstractString`: Template file for `src/<module>.jl`.
 """
-@with_kw_noshow mutable struct SrcDir <: BasicPlugin
+@with_kw_noshow mutable struct SrcDir <: FilePugin
     file::String = default_file("src", "module.jl")
     destination::String = ""
 end

--- a/src/plugins/tagbot.jl
+++ b/src/plugins/tagbot.jl
@@ -34,7 +34,7 @@ Adds GitHub release support via [TagBot](https://github.com/JuliaRegistries/TagB
 - `dispatch::Bool`: Whether or not to enable the `dispatch` option.
 - `dispatch_delay::Int`: Number of minutes to delay for dispatch events.
 """
-@with_kw_noshow struct TagBot <: BasicPlugin
+@with_kw_noshow struct TagBot <: FilePugin
     file::String = default_file("github", "workflows", "TagBot.yml")
     destination::String = "TagBot.yml"
     cron::String = "0 0 * * *"

--- a/src/plugins/tests.jl
+++ b/src/plugins/tests.jl
@@ -16,7 +16,7 @@ Sets up testing for packages.
     Managing test dependencies with `test/Project.toml` is only supported
     in Julia 1.2 and later.
 """
-@with_kw_noshow struct Tests <: BasicPlugin
+@with_kw_noshow struct Tests <: FilePugin
     file::String = default_file("test", "runtests.jl")
     project::Bool = false
 end
@@ -26,7 +26,7 @@ destination(::Tests) = joinpath("test", "runtests.jl")
 view(::Tests, ::Template, pkg::AbstractString) = Dict("PKG" => pkg)
 
 function validate(p::Tests, t::Template)
-    invoke(validate, Tuple{BasicPlugin, Template}, p, t)
+    invoke(validate, Tuple{FilePugin, Template}, p, t)
     p.project && t.julia < v"1.2" && @warn string(
         "Tests: The project option is set to create a project (supported in Julia 1.2 and later) ",
         "but a Julia version older than 1.2 ($(t.julia)) is supported by the template",
@@ -34,8 +34,8 @@ function validate(p::Tests, t::Template)
 end
 
 function hook(p::Tests, t::Template, pkg_dir::AbstractString)
-    # Do the normal BasicPlugin behaviour to create the test script.
-    invoke(hook, Tuple{BasicPlugin, Template, AbstractString}, p, t, pkg_dir)
+    # Do the normal FilePugin behaviour to create the test script.
+    invoke(hook, Tuple{FilePugin, Template, AbstractString}, p, t, pkg_dir)
 
     # Then set up the test depdendency in the chosen way.
     f = p.project ? make_test_project : add_test_dependency

--- a/test/plugin.jl
+++ b/test/plugin.jl
@@ -1,6 +1,6 @@
 # Don't move this line from the top, please. {{X}} {{Y}} {{Z}}
 
-struct BasicTest <: PT.BasicPlugin
+struct BasicTest <: PT.FilePugin
     a::String
     b::Bool
 end
@@ -13,7 +13,7 @@ PT.view(::BasicTest, ::Template, ::AbstractString) = Dict("X" => 0, "Y" => 2)
 PT.user_view(::BasicTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3)
 
 @testset "Plugins" begin
-    @testset "BasicPlugin" begin
+    @testset "FilePugin" begin
         p = BasicTest("foo", true)
         t = tpl(; plugins=[p])
 


### PR DESCRIPTION
The new name does a much better job of describing what they're actually for, IMO.
One thing I wish we could do is deprecate `BasicPlugin` in a way that triggers the warning when it's subtyped, but I don't think that's possible.