### PR TITLE
Replace ReferenceTests with our own function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,11 +17,11 @@ Parameters = "0.12"
 julia = "1"
 
 [extras]
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 SimpleMock = "a896ed2c-15a5-4479-b61d-a0e88e2a1d25"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Suppressor", "Random", "ReferenceTests", "SimpleMock", "Test"]
+test = ["DeepDiffs", "Random", "Suppressor", "SimpleMock", "Test"]

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -358,12 +358,9 @@ They should pass, and there will be new files in `test/fixtures`.
 Check them to make sure that they contain exactly what you would expect!
 
 For changes to existing plugins, update the plugin options appropriately in the "Wacky options" test set.
-Rather than using `Pkg.test` to run the tests in this case, use `include("test/runtests.jl")`.
-Running the tests in an interactive session will give you the option to review and accept changes to the fixtures, updating the files automatically (see [ReferenceTests](https://github.com/Evizero/ReferenceTests.jl) for more details).
-Before you can do this, you'll need to add PkgTemplates' test requirements to your current environment.
+Failing tests  will give you the option to review and accept changes to the fixtures, updating the files automatically for you.
 
 ### Updating "Show" Tests
 
 Depending on what you've changed, the tests in `test/show.jl` might fail.
-To fix those, you'll need to update the `expected` value to match what is actually displayed in a Julia REPL.
-The test error itself is usually not very helpful, so it's easiest to launch a REPL, evaluate `Template()`, and copy-paste the relevant parts back into the test file.
+To fix those, you'll need to update the `expected` value to match what is actually displayed in a Julia REPL (assuming that the new value is correct).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Pkg: Pkg, PackageSpec, TOML
 using Random: Random, randstring
 using Test: @test, @testset, @test_logs, @test_throws
 
-using ReferenceTests: @test_reference
+using DeepDiffs: deepdiff
 using SimpleMock: mock
 using Suppressor: @suppress
 
@@ -33,6 +33,16 @@ function with_pkg(f::Function, t::Template, pkg::AbstractString=pkgname())
         # We're going to delete the package directory anyways, so just ignore any errors.
         PT.version_of(pkg) === nothing || try @suppress Pkg.rm(pkg) catch; end
         rm(joinpath(t.dir, pkg); recursive=true, force=true)
+    end
+end
+
+function print_diff(a, b)
+    old = Base.have_color
+    @eval Base have_color = true
+    try
+        println(deepdiff(a, b))
+    finally
+        @eval Base have_color = $old
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,6 +1,15 @@
 const TEMPLATES_DIR = contractuser(PT.TEMPLATES_DIR)
 const LICENSES_DIR = joinpath(TEMPLATES_DIR, "licenses")
 
+function test_show(expected::AbstractString, observed::AbstractString)
+    if expected == observed
+        @test true
+    else
+        print_diff(expected, observed)
+        @test :expected == :observed
+    end
+end
+
 @testset "Show methods" begin
     @testset "Plugins" begin
         expected = """
@@ -9,7 +18,7 @@ const LICENSES_DIR = joinpath(TEMPLATES_DIR, "licenses")
               destination: "README.md"
               inline_badges: false
             """
-        @test sprint(show, MIME("text/plain"), Readme()) == rstrip(expected)
+        test_show(rstrip(expected), sprint(show, MIME("text/plain"), Readme()))
     end
 
     @testset "Template" begin
@@ -62,7 +71,7 @@ const LICENSES_DIR = joinpath(TEMPLATES_DIR, "licenses")
                   file: "$(joinpath(TEMPLATES_DIR, "test", "runtests.jl"))"
                   project: false
             """
-        @test sprint(show, MIME("text/plain"), tpl(; authors=USER)) == rstrip(expected)
+        test_show(rstrip(expected), sprint(show, MIME("text/plain"), tpl(; authors=USER)))
     end
 
     @testset "show as serialization" begin


### PR DESCRIPTION
ReferenceTests has a bunch of image-specific stuff that we don't care
about, and building it (or rather, its dependencies) sometimes chokes the CI.
This way, we also get interactive prompts when running Pkg.test from the REPL,
and the `show` tests display nice diffs now, too.