### PR TITLE
Update the CompatHelper template

### DIFF
--- a/templates/github/workflows/CompatHelper.yml
+++ b/templates/github/workflows/CompatHelper.yml
@@ -1,14 +1,17 @@
 name: CompatHelper
+
 on:
   schedule:
     - cron: <<&CRON>>
+
 jobs:
-  build:
+  CompatHelper:
     runs-on: ubuntu-latest
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
CompatHelper now supports SSH deploy keys. This pull request updates the CompatHelper template to support this new feature.

---

Just a note: You'll notice that the new template has a line that looks like this:
```yaml
COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
```

If the user does not want or need to use SSH deploy keys, they don't need to set the `COMPATHELPER_PRIV` secret. And if the `COMPATHELPER_PRIV` secret is not set, CompatHelper will silently ignore it.

So we can include this line in the template unconditionally. If the `COMPATHELPER_PRIV` secret is set, CompatHelper will automatically detect it and use it. Otherwise, it will be ignored.

cc: @christopher-dG 