### PR TITLE
Make the .jl remote suffix optional

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/plugins/git.jl
+++ b/src/plugins/git.jl
@@ -4,6 +4,7 @@
         name=nothing,
         email=nothing,
         ssh=false,
+        jl=true,
         manifest=false,
         gpgsign=false,
     )
@@ -17,6 +18,7 @@ Creates a Git repository and a `.gitignore` file.
 - `email::AbstractString`: Your email address, if you have not set `user.email` with Git.
 - `ssh::Bool`: Whether or not to use SSH for the remote.
   If left unset, HTTPS is used.
+- `jl::Bool`: Whether or not to add a `.jl` suffix to the remote URL.
 - `manifest::Bool`: Whether or not to commit `Manifest.toml`.
 - `gpgsign::Bool`: Whether or not to sign commits with your GPG key.
   This option requires that the Git CLI is installed,
@@ -27,6 +29,7 @@ Creates a Git repository and a `.gitignore` file.
     name::Union{String, Nothing} = nothing
     email::Union{String, Nothing} = nothing
     ssh::Bool = false
+    jl::Bool = true
     manifest::Bool = false
     gpgsign::Bool = false
 end
@@ -64,10 +67,11 @@ function prehook(p::Git, t::Template, pkg_dir::AbstractString)
         end
         commit(p, repo, pkg_dir, "Initial commit")
         pkg = basename(pkg_dir)
+        suffix = p.jl ? ".jl" : ""
         url = if p.ssh
-            "git@$(t.host):$(t.user)/$pkg.jl.git"
+            "git@$(t.host):$(t.user)/$pkg$suffix.git"
         else
-            "https://$(t.host)/$(t.user)/$pkg.jl"
+            "https://$(t.host)/$(t.user)/$pkg$suffix"
         end
         LibGit2.with(GitRemote(repo, "origin", url)) do remote
             LibGit2.add_fetch!(repo, remote, "refs/heads/master")

--- a/test/git.jl
+++ b/test/git.jl
@@ -37,6 +37,16 @@
         end
     end
 
+    @testset "Without .jl suffix" begin
+        t = tpl(; plugins=[Git(; jl=false)])
+        with_pkg(t) do pkg
+            LibGit2.with(GitRepo(joinpath(t.dir, pkg))) do repo
+                remote = LibGit2.get(GitRemote, repo, "origin")
+                @test !occursin(".jl", LibGit2.url(remote))
+            end
+        end
+    end
+
     @testset "With custom name/email" begin
         t = tpl(; plugins=[Git(; name="me", email="a@b.c")])
         with_pkg(t) do pkg

--- a/test/show.jl
+++ b/test/show.jl
@@ -41,6 +41,7 @@ end
                   name: nothing
                   email: nothing
                   ssh: false
+                  jl: true
                   manifest: false
                   gpgsign: false
                 License:


### PR DESCRIPTION
Had a nice conversation with @aminya who is looking at PkgTemplates for non-Julia stuff. All the Julia-specific plugins can be disabled easily, but Git only requires this small change to be language-agnostic.