### PR TITLE
Cache artifacts in Travis, AppVeyor, GitHubActions, and Cirrus

### DIFF
--- a/templates/appveyor.yml
+++ b/templates/appveyor.yml
@@ -8,6 +8,8 @@ platform:
 {{#PLATFORMS}}
   - {{{.}}}
 {{/PLATFORMS}}
+cache:
+  - '%USERPROFILE%\.julia\artifacts'
 {{#HAS_ALLOW_FAILURES}}
 matrix:
   allow_failures:

--- a/templates/cirrus.yml
+++ b/templates/cirrus.yml
@@ -2,6 +2,8 @@ freebsd_instance:
   image: {{{IMAGE}}}
 task:
   name: FreeBSD
+  artifacts_cache:
+    folder: ~/.julia/artifacts
   env:
 {{#VERSIONS}}
     JULIA_VERSION: {{{.}}}

--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -36,6 +36,16 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       <<#HAS_CODECOV>>

--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -14,6 +14,9 @@ arch:
 {{#ARCH}}
   - {{{.}}}
 {{/ARCH}}
+cache:
+  directories:
+    - ~/.julia/artifacts
 jobs:
   fast_finish: true
 {{#HAS_ALLOW_FAILURES}}

--- a/test/fixtures/AllPlugins/.appveyor.yml
+++ b/test/fixtures/AllPlugins/.appveyor.yml
@@ -6,6 +6,8 @@ environment:
     - julia_version: nightly
 platform:
   - x64
+cache:
+  - '%USERPROFILE%\.julia\artifacts'
 matrix:
   allow_failures:
     - julia_version: nightly

--- a/test/fixtures/AllPlugins/.cirrus.yml
+++ b/test/fixtures/AllPlugins/.cirrus.yml
@@ -2,6 +2,8 @@ freebsd_instance:
   image: freebsd-12-0-release-amd64
 task:
   name: FreeBSD
+  artifacts_cache:
+    folder: ~/.julia/artifacts
   env:
     JULIA_VERSION: 1.0
     JULIA_VERSION: 1.4

--- a/test/fixtures/AllPlugins/.github/workflows/ci.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@latest

--- a/test/fixtures/AllPlugins/.travis.yml
+++ b/test/fixtures/AllPlugins/.travis.yml
@@ -12,6 +12,9 @@ os:
   - windows
 arch:
   - x64
+cache:
+  directories:
+    - ~/.julia/artifacts
 jobs:
   fast_finish: true
   allow_failures:

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
   docs:

--- a/test/fixtures/DocumenterTravis/.travis.yml
+++ b/test/fixtures/DocumenterTravis/.travis.yml
@@ -12,6 +12,9 @@ os:
   - windows
 arch:
   - x64
+cache:
+  directories:
+    - ~/.julia/artifacts
 jobs:
   fast_finish: true
   allow_failures:

--- a/test/fixtures/WackyOptions/.appveyor.yml
+++ b/test/fixtures/WackyOptions/.appveyor.yml
@@ -6,6 +6,8 @@ environment:
 platform:
   - x64
   - x86
+cache:
+  - '%USERPROFILE%\.julia\artifacts'
 branches:
   only:
     - master

--- a/test/fixtures/WackyOptions/.cirrus.yml
+++ b/test/fixtures/WackyOptions/.cirrus.yml
@@ -2,6 +2,8 @@ freebsd_instance:
   image: freebsd-123
 task:
   name: FreeBSD
+  artifacts_cache:
+    folder: ~/.julia/artifacts
   env:
     JULIA_VERSION: 1.1
     JULIA_VERSION: 1.2

--- a/test/fixtures/WackyOptions/.github/workflows/ci.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/ci.yml
@@ -28,5 +28,15 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/test/fixtures/WackyOptions/.travis.yml
+++ b/test/fixtures/WackyOptions/.travis.yml
@@ -12,6 +12,9 @@ arch:
   - x64
   - x86
   - arm64
+cache:
+  directories:
+    - ~/.julia/artifacts
 jobs:
   fast_finish: true
   exclude:


### PR DESCRIPTION
Closes #166
I've tested Travis, AppVeyor, and GHA, but I couldn't get Cirrus to pick up on my repo for some reason. According to the docs it should work.
GitLab doesn't allow caching files outside of the repository directory, so caching can't be used there. DroneCI's caching looks a bit more complicated so maybe I'll look at it another day, it's not used frequently anyways.