### PR TITLE
Use Julia 1.x for doc builds on Travis and GHA

### DIFF
--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.0'
+          version: '1'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -37,7 +37,7 @@ jobs:
 {{#HAS_DOCUMENTER}}
   include:
     - stage: Documentation
-      julia: {{{VERSION}}}
+      julia: 1
       script: |
         julia --project=docs -e '
           using Pkg

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.0'
+          version: '1'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/test/fixtures/DocumenterTravis/.travis.yml
+++ b/test/fixtures/DocumenterTravis/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     - julia: nightly
   include:
     - stage: Documentation
-      julia: 1.0
+      julia: 1
       script: |
         julia --project=docs -e '
           using Pkg


### PR DESCRIPTION
This was kind of mentioned during #139, I think it's probably safer these days to use the latest Julia. It's more likely that a package fails to load on 1.0 than on latest 1.x, I think. Also I think 1.0 was chosen back when plain 1 wasn't a thing.