### PR TITLE
Catch missing user exception in interactive mode and prompt for it

### DIFF
--- a/test/template.jl
+++ b/test/template.jl
@@ -4,7 +4,7 @@
     @testset "Template constructor" begin
         @testset "user" begin
             mock(PT.default_user => () -> "") do _du
-                @test_throws ArgumentError Template()
+                @test_throws PT.MissingUserException Template()
                 @test isempty(Template(; plugins=[!Git]).user)
             end
             mock(PT.default_user => () -> "username") do _du


### PR DESCRIPTION
Closes #179 

```jl
julia> Template(; interactive=true)
Template keywords to customize:
[press: d=done, a=all, n=none]
 > [ ] user
   [ ] authors
   [ ] dir
   [ ] host
   [ ] julia
   [ ] plugins
Enter value for 'user' (String, required):
Enter value for 'user' (String, required):
Enter value for 'user' (String, required):
Enter value for 'user' (String, required):
Enter value for 'user' (String, required): ok fine here's my username
Template:
# ...
```