### PR TITLE
Update Github actions CI

### DIFF
--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -52,10 +52,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:
-          file: ./lcov.info
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
+          file: lcov.info
       <</HAS_CODECOV>>
       <<#HAS_COVERALLS>>
       - uses: julia-actions/julia-uploadcoveralls@latest

--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -49,9 +49,13 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       <<#HAS_CODECOV>>
-      - uses: julia-actions/julia-uploadcodecov@latest
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
       <</HAS_CODECOV>>
       <<#HAS_COVERALLS>>
       - uses: julia-actions/julia-uploadcoveralls@latest

--- a/test/fixtures/AllPlugins/.github/workflows/ci.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/ci.yml
@@ -36,9 +36,10 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-uploadcodecov@latest
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
       - uses: julia-actions/julia-uploadcoveralls@latest
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}


### PR DESCRIPTION
The first commit uses the codecov action (https://github.com/codecov/codecov-action) which @SaschaMann recommended to me (pointing to https://github.com/uva-bi-sdad/COVID_Tracking_Clean/blob/master/.github/workflows/ci.yml#L64-L70) when I was having issues with codecov mixing up which branch was which. One nice thing about it is that a token is not required for public repos.

The second commit is a bit more opinionated (and I understand if you don't want to include it) and runs CI only on pushes or PRs to the master branch, and ignores changes to the license, readme, and CompatHelper and Tagbot actions. I end up almost always wanting this in my repos, especially since github actions don't autocancel (so push a few commits and then make a PR, and CI doesn't run on the PR for awhile since it has to process through the commits). I imagine it might be better if ignoring CompatHelper and Tagbot are gated on those plugins being used, but I wasn't sure how to do that and ignoring the paths doesn't really hurt anyway.