### PR TITLE
Make extra_versions accept any string, strip quotes from input

### DIFF
--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -105,7 +105,7 @@ end
 
 function convert_input(P::Type, T::Type{<:Vector}, s::AbstractString)
     startswith(s, '[') && endswith(s, ']') && (s = s[2:end-1])
-    xs = map(strip, split(s, ","))
+    xs = map(x -> strip(x, [' ', '\t', '"']), split(s, ","))
     return map(x -> convert_input(P, eltype(T), x), xs)
 end
 
@@ -123,6 +123,7 @@ function prompt(P::Type, ::Type{T}, ::Val{name}, ::Nothing=nothing) where {T, na
     default = defaultkw(P, name)
     input = Base.prompt(pretty_message("Enter value for '$name' ($tips)"))
     input === nothing && throw(InterruptException())
+    input = strip(input, '"')
     return if isempty(input)
         default
     else

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -392,7 +392,8 @@ Combine `t`'s Julia version with `versions`, and format them as `major.minor`.
 This is useful for creating lists of versions to be included in CI configurations.
 """
 function collect_versions(t::Template, versions::Vector)
-    vs = map(format_version, [t.julia, versions...])
+    custom = map(v -> v isa VersionNumber ? format_version(v) : string(v), versions)
+    vs = map(v -> lstrip(v, 'v'), [format_version(t.julia); custom])
     return sort(unique(vs))
 end
 
@@ -408,4 +409,4 @@ is_ci(::Plugin) = false
 is_ci(::AllCI) = true
 
 needs_username(::AllCI) = true
-customizable(::Type{<:AllCI}) = (:extra_versions => Vector{VersionNumber},)
+customizable(::Type{<:AllCI}) = (:extra_versions => Vector{String},)

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -156,7 +156,7 @@ end
             @test PT.interactive(TravisCI) == TravisCI(;
                 arm64=true,
                 coverage=false,
-                extra_versions=[v"1.1", v"1.2"],
+                extra_versions=["1.1", "v1.2"],
                 file="x.txt",
                 linux=true,
                 osx=false,
@@ -180,6 +180,25 @@ end
                 CR,                  # Choose MIT for name (it's at the top)
             )
             @test PT.interactive(License) == License(; destination="COPYING", name="MIT")
+        end
+
+        @testset "Quotes" begin
+            print(
+                stdin.buffer,
+                CR, DOWN^2, CR, DONE,  # Customize user and dir
+                "\"me\"", LF,          # Enter user with quotes
+                "\"~\"", LF,           # Enter home dir with quotes
+            )
+            @test Template(; interactive=true) == Template(; user="me", dir="~")
+
+            print(
+                stdin.buffer,
+                DOWN^2, CR, DONE,                        # Customize extra_versions
+                "\"1.1.1\", \"^1.5\", \"nightly\"", LF,  # Enter versions with quotes
+            )
+            @test PT.interactive(TravisCI) == TravisCI(;
+                extra_versions=["1.1.1", "^1.5", "nightly"],
+            )
         end
 
         @testset "Union{T, Nothing} weirdness" begin


### PR DESCRIPTION
Closes #183
Closes #184

There's a slight behaviour change here but I think it's for the better: if a user enters `MAJOR.MINOR.PATCH` in `extra_versions`, then the full version number with patch shows up in the file. Previously it would just be `MAJOR.MINOR`. Defaults however are not changed. We also support version ranges now too, which GitHub Actions supports.