### PR TITLE
Documenter: run doctests by default

### DIFF
--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            import Documenter
+            import {{{PKG}}}
+            Documenter.doctest({{{PKG}}})'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Documenter: doctest
-            using {{{PKG}}}
-            doctest({{{PKG}}})'
+            using <<&PKG>>
+            doctest(<<&PKG>>)'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
             Pkg.instantiate()'
       - run: |
           julia --project=docs -e '
-            import Documenter
-            import {{{PKG}}}
-            Documenter.doctest({{{PKG}}})'
+            using Documenter: doctest
+            using {{{PKG}}}
+            doctest({{{PKG}}})'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/gitlab-ci.yml
+++ b/templates/gitlab-ci.yml
@@ -37,6 +37,9 @@ pages:
         using Pkg
         Pkg.develop(PackageSpec(path=pwd()))
         Pkg.instantiate()
+        using Documenter: doctest
+        using {{{PKG}}}
+        doctest({{{PKG}}})
         include("docs/make.jl")'
     - mkdir -p public
     - mv docs/build public/dev

--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -48,7 +48,7 @@ jobs:
           Pkg.instantiate()
           using Documenter: doctest
           using {{{PKG}}}
-          Documenter.doctest({{{PKG}}})
+          doctest({{{PKG}}})
           include("docs/make.jl")'
       after_success: skip
 {{/HAS_DOCUMENTER}}

--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -46,8 +46,8 @@ jobs:
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
-          import Documenter
-          import {{{PKG}}}
+          using Documenter: doctest
+          using {{{PKG}}}
           Documenter.doctest({{{PKG}}})
           include("docs/make.jl")'
       after_success: skip

--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -46,6 +46,9 @@ jobs:
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
+          import Documenter
+          import {{{PKG}}}
+          Documenter.doctest({{{PKG}}})
           include("docs/make.jl")'
       after_success: skip
 {{/HAS_DOCUMENTER}}

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: doctest
+            using DocumenterGitHubActions
+            doctest(DocumenterGitHubActions)'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/fixtures/DocumenterTravis/.travis.yml
+++ b/test/fixtures/DocumenterTravis/.travis.yml
@@ -27,5 +27,8 @@ jobs:
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
+          using Documenter: doctest
+          using DocumenterTravis
+          doctest(DocumenterTravis)
           include("docs/make.jl")'
       after_success: skip

--- a/test/fixtures/WackyOptions/.gitlab-ci.yml
+++ b/test/fixtures/WackyOptions/.gitlab-ci.yml
@@ -18,6 +18,9 @@ pages:
         using Pkg
         Pkg.develop(PackageSpec(path=pwd()))
         Pkg.instantiate()
+        using Documenter: doctest
+        using WackyOptions
+        doctest(WackyOptions)
         include("docs/make.jl")'
     - mkdir -p public
     - mv docs/build public/dev


### PR DESCRIPTION
Currently, if doctests are failing, the CI job will still pass, which means that it is easy to doctest failures to fly under the radar.

This PR runs the doctests by default in a step that will fail the CI job if the doctests fail.