### PR TITLE
CompatHelper: by default, use the `DOCUMENTER_KEY` SSH deploy key

### DIFF
--- a/templates/github/workflows/CompatHelper.yml
+++ b/templates/github/workflows/CompatHelper.yml
@@ -2,13 +2,15 @@ name: CompatHelper
 on:
   schedule:
     - cron: <<&CRON>>
+  workflow_dispatch:
 jobs:
-  build:
+  CompatHelper:
     runs-on: ubuntu-latest
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
This pull request makes the following changes:
1. Use the `DOCUMENTER_KEY` SSH deploy key by default.
2. Enables the `workflow_dispatch` trigger.

cc: @christopher-dG 
cc: @timholy 