### PR TITLE
TagBot: use the `DOCUMENTER_KEY` SSH deploy key by default

### DIFF
--- a/src/plugins/tagbot.jl
+++ b/src/plugins/tagbot.jl
@@ -39,7 +39,7 @@ Adds GitHub release support via [TagBot](https://github.com/JuliaRegistries/TagB
     destination::String = "TagBot.yml"
     cron::String = "0 0 * * *"
     token::Secret = Secret("GITHUB_TOKEN")
-    ssh::Union{Secret, Nothing} = nothing
+    ssh::Union{Secret, Nothing} = Secret("DOCUMENTER_KEY")
     ssh_password::Union{Secret, Nothing} = nothing
     changelog::Union{String, Nothing} = nothing
     changelog_ignore::Union{Vector{String}, Nothing} = nothing


### PR DESCRIPTION
Fixes #206 

cc: @christopher-dG 
h/t @timholy for having this idea originally in #162 