### PR TITLE
use dynamic path to make sysimg happy

### DIFF
--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -106,7 +106,7 @@ abstract type FilePlugin <: Plugin end
 Return a path relative to the default template file directory
 (`PkgTemplates/templates`).
 """
-default_file(paths::AbstractString...) = contractuser(joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...))
+default_file(paths::AbstractString...) = joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...)
 
 """
     view(::Plugin, ::Template, pkg::AbstractString) -> Dict{String, Any}

--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -1,4 +1,3 @@
-const TEMPLATES_DIR = normpath(joinpath(@__DIR__, "..", "templates"))
 const DEFAULT_PRIORITY = 1000
 
 """
@@ -105,9 +104,9 @@ abstract type FilePlugin <: Plugin end
     default_file(paths::AbstractString...) -> String
 
 Return a path relative to the default template file directory
-(`$(contractuser(TEMPLATES_DIR))`).
+(`PkgTemplates/templates`).
 """
-default_file(paths::AbstractString...) = joinpath(TEMPLATES_DIR, paths...)
+default_file(paths::AbstractString...) = joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...)
 
 """
     view(::Plugin, ::Template, pkg::AbstractString) -> Dict{String, Any}

--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -106,7 +106,9 @@ abstract type FilePlugin <: Plugin end
 Return a path relative to the default template file directory
 (`PkgTemplates/templates`).
 """
-default_file(paths::AbstractString...) = joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...)
+function default_file(paths::AbstractString...)
+    return joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...)
+end
 
 """
     view(::Plugin, ::Template, pkg::AbstractString) -> Dict{String, Any}

--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -106,7 +106,7 @@ abstract type FilePlugin <: Plugin end
 Return a path relative to the default template file directory
 (`PkgTemplates/templates`).
 """
-default_file(paths::AbstractString...) = joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...)
+default_file(paths::AbstractString...) = contractuser(joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...))
 
 """
     view(::Plugin, ::Template, pkg::AbstractString) -> Dict{String, Any}

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,6 +1,6 @@
 @info "Running show tests"
 
-const TEMPLATES_DIR = contractuser(PT.TEMPLATES_DIR)
+const TEMPLATES_DIR = PT.default_file()
 const LICENSES_DIR = joinpath(TEMPLATES_DIR, "licenses")
 
 function test_show(expected::AbstractString, observed::AbstractString)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,6 +1,6 @@
 @info "Running show tests"
 
-const TEMPLATES_DIR = PT.default_file()
+const TEMPLATES_DIR = contractuser(PT.default_file())
 const LICENSES_DIR = joinpath(TEMPLATES_DIR, "licenses")
 
 function test_show(expected::AbstractString, observed::AbstractString)


### PR DESCRIPTION
currently, if a system image is compiled that contains PkgTemplates, the `Template` functionality won't be redistributable, since it is using a global constant that get evaluated to be a very specific path on the build machine but not the user's actual path during compilation. Then you maybe get something like MIT license not found error.

since TEMPLATES_DIR is only used for `default_files` I think it's OK to just use `pathof`.