### PR TITLE
Template for GitHub Actions CI: More descriptive job names

### DIFF
--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/test/fixtures/AllPlugins/.github/workflows/ci.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/test/fixtures/WackyOptions/.github/workflows/ci.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Currently, the job names look like this:
```
CI / Julia 1.0 - ubuntu-latest - x64
```

Suppose that I mark the `CI / Julia 1.0 - ubuntu-latest - x64` job as "required" in the GitHub protected branch settings.

This requirement will be matched by both "push" and "pull request" builds.

However, when users mark CI jobs as required in the protected branch settings, the implication is usually that they are referring to the pull request builds. Pull request builds are testing the merge commit that would result from merging the PR into `master`. In contrast, push builds are testing the head commit.

The problem with the current job names is that protected branch settings cannot distinguish between "push" and "pull request" builds.

After this PR, the job names look like this:
```
CI / Julia 1.0 - ubuntu-latest - x64 - pull_request
```

Now, I can go into the GitHub protected branch settings and mark `CI / Julia 1.0 - ubuntu-latest - x64 - pull_request` as required. This requirement will only be satisfied if the pull request build passes.