### PR TITLE
GitHub Actions CI for the PkgTemplates.jl repo: Disable fast failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         version:
           - '1.0'


### PR DESCRIPTION
Fast failures often make it impossible to figure out which jobs are actually passing.