### PR TITLE
Don't bork the remote config

### DIFF
--- a/src/plugins/git.jl
+++ b/src/plugins/git.jl
@@ -82,10 +82,7 @@ function prehook(p::Git, t::Template, pkg_dir::AbstractString)
             LibGit2.branch!(repo, branch)
             delete_branch(GitReference(repo, "refs/heads/$default"))
         end
-        LibGit2.with(GitRemote(repo, "origin", url)) do remote
-            LibGit2.add_fetch!(repo, remote, "refs/heads/$branch")
-            LibGit2.add_push!(repo, remote, "refs/heads/$branch")
-        end
+        close(GitRemote(repo, "origin", url))
     end
 end
 


### PR DESCRIPTION
Turns out that some of the fiddling I was doing with the Git remote was actually creating a subtly invalid config that I only discovered when I tried to run `LibGit2.remote_delete` on it. By taking away that fiddling, we end up with exactly what you get after running `git remote add origin <url>`.