### PR TITLE
GHA: Don't use potentially breaking version tags

### DIFF
--- a/templates/github/workflows/ci.yml
+++ b/templates/github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       <<#HAS_CODECOV>>
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
@@ -56,7 +56,7 @@ jobs:
           file: lcov.info
       <</HAS_CODECOV>>
       <<#HAS_COVERALLS>>
-      - uses: julia-actions/julia-uploadcoveralls@latest
+      - uses: julia-actions/julia-uploadcoveralls@v1
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       <</HAS_COVERALLS>>

--- a/test/fixtures/AllPlugins/.github/workflows/ci.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-      - uses: julia-actions/julia-uploadcoveralls@latest
+      - uses: julia-actions/julia-uploadcoveralls@v1
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/test/fixtures/WackyOptions/.github/workflows/ci.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
I'm not too familiar with this repo, are there other places where this needs to be changed that I missed?