### PR TITLE
Remove `L` prefix before line segment of repo URL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.13"
+version = "0.7.14"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using PkgTemplates: PkgTemplates
 makedocs(;
     modules=[PkgTemplates],
     authors="Chris de Graaf, Invenia Technical Computing Corporation",
-    repo="https://github.com/invenia/PkgTemplates.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/invenia/PkgTemplates.jl/blob/{commit}{path}#{line}",
     sitename="PkgTemplates.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/templates/docs/make.jl
+++ b/templates/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!({{{PKG}}}, :DocTestSetup, :(using {{{PKG}}}); recursive=true
 makedocs(;
     modules=[{{{PKG}}}],
     authors="{{{AUTHORS}}}",
-    repo="https://{{{REPO}}}/blob/{commit}{path}#L{line}",
+    repo="https://{{{REPO}}}/blob/{commit}{path}#{line}",
     sitename="{{{PKG}}}.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/AllPlugins/docs/make.jl
+++ b/test/fixtures/AllPlugins/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!(AllPlugins, :DocTestSetup, :(using AllPlugins); recursive=tr
 makedocs(;
     modules=[AllPlugins],
     authors="tester",
-    repo="https://github.com/tester/AllPlugins.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/tester/AllPlugins.jl/blob/{commit}{path}#{line}",
     sitename="AllPlugins.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/DocumenterGitHubActions/docs/make.jl
+++ b/test/fixtures/DocumenterGitHubActions/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!(DocumenterGitHubActions, :DocTestSetup, :(using DocumenterGi
 makedocs(;
     modules=[DocumenterGitHubActions],
     authors="tester",
-    repo="https://github.com/tester/DocumenterGitHubActions.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/tester/DocumenterGitHubActions.jl/blob/{commit}{path}#{line}",
     sitename="DocumenterGitHubActions.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/DocumenterTravis/docs/make.jl
+++ b/test/fixtures/DocumenterTravis/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!(DocumenterTravis, :DocTestSetup, :(using DocumenterTravis); 
 makedocs(;
     modules=[DocumenterTravis],
     authors="tester",
-    repo="https://github.com/tester/DocumenterTravis.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/tester/DocumenterTravis.jl/blob/{commit}{path}#{line}",
     sitename="DocumenterTravis.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/WackyOptions/docs/make.jl
+++ b/test/fixtures/WackyOptions/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!(WackyOptions, :DocTestSetup, :(using WackyOptions); recursiv
 makedocs(;
     modules=[WackyOptions],
     authors="tester",
-    repo="https://x.com/tester/WackyOptions.jl/blob/{commit}{path}#L{line}",
+    repo="https://x.com/tester/WackyOptions.jl/blob/{commit}{path}#{line}",
     sitename="WackyOptions.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",


### PR DESCRIPTION
i don't know how to explain this one... this `L` has been here a long time, but it seems unnecessary as it always results in URLs like `https://github.com/etc..../foo.jl#LL1-2` with the double `LL`. Here's an example result of this change:
```diff
-https://github.com/invenia/PkgTemplates.jl/blob/89e6dd5e39641c8d40b2492d307e361a83b6dd0f/src/plugin.jl#LL155-L162
+https://github.com/invenia/PkgTemplates.jl/blob/89e6dd5e39641c8d40b2492d307e361a83b6dd0f/src/plugin.jl#L155-L162
```
I tested with Documenter 0.23, 0.24 and 0.25 and it always gives this same `LL` result. 

As you can test for yourself using the two example links above, both work i.e. both link correctly to the source code of the `PkgTemplates.tags(::Plugin)` function.

However, the `LL` doesn't (or doesn't any longer??) work on GitLab. I don't have an open-source GitLab repo where i can show this, but somthing like `https://gitlab.com/etc..../foo.jl#LL1-2` does not highlight lines 1-2 whereas `https://github.com/etc..../foo.jl#L1-2` (with the single `L`) does highlight the intended lines.