### PR TITLE
allow changing default template dir

### DIFF
--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -1,4 +1,5 @@
 const DEFAULT_PRIORITY = 1000
+const DEFAULT_TEMPLATE_DIR = Ref{String}(joinpath(pkgdir(PkgTemplates), "templates"))
 
 """
     @plugin struct ... end
@@ -107,7 +108,7 @@ Return a path relative to the default template file directory
 (`PkgTemplates/templates`).
 """
 function default_file(paths::AbstractString...)
-    return joinpath(dirname(dirname(pathof(PkgTemplates))), "templates", paths...)
+    return joinpath(DEFAULT_TEMPLATE_DIR[], paths...)
 end
 
 """

--- a/src/plugin.jl
+++ b/src/plugin.jl
@@ -1,5 +1,5 @@
 const DEFAULT_PRIORITY = 1000
-const DEFAULT_TEMPLATE_DIR = Ref{String}(joinpath(pkgdir(PkgTemplates), "templates"))
+const DEFAULT_TEMPLATE_DIR = Ref{String}(joinpath(dirname(dirname(pathof(PkgTemplates))), "templates"))
 
 """
     @plugin struct ... end
@@ -107,9 +107,7 @@ abstract type FilePlugin <: Plugin end
 Return a path relative to the default template file directory
 (`PkgTemplates/templates`).
 """
-function default_file(paths::AbstractString...)
-    return joinpath(DEFAULT_TEMPLATE_DIR[], paths...)
-end
+default_file(paths::AbstractString...) = joinpath(DEFAULT_TEMPLATE_DIR[], paths...)
 
 """
     view(::Plugin, ::Template, pkg::AbstractString) -> Dict{String, Any}


### PR DESCRIPTION
this follows #209  the current implementation is still not relocatable - the directory PkgTemplate may not exist if it is compiled into the system image, so one way to get rid of it is to allow reset some of the default paths to new places.