### PR TITLE
GitHub Actions: Put the doctests into a separate job

### DIFF
--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -74,14 +74,27 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+  doctests:
+    name: Doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest
             using <<&PKG>>
             DocMeta.setdocmeta!(<<&PKG>>, :DocTestSetup, :(using <<&PKG>>); recursive=true)
             doctest(<<&PKG>>)'
-      - run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
   <</HAS_DOCUMENTER>>


### PR DESCRIPTION
This allows e.g.:
1. Docs to build even if there is a doctest failure. Doctests can fail between minor versions of Julia, so doctests failures should not necessarily preclude the docs from building.
2. Using different versions of Julia for the docs vs. the doctests (we just did this in LoopVectorization.jl)