### PR TITLE
GHA badge needs branch argument

### DIFF
--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -62,7 +62,7 @@ tags(::GitHubActions) = "<<", ">>"
 
 badges(::GitHubActions) = Badge(
     "Build Status",
-    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/workflows/CI/badge.svg",
+    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/workflows/CI/badge.svg?branch=main",
     "https://github.com/{{{USER}}}/{{{PKG}}}.jl/actions",
 )
 


### PR DESCRIPTION
Otherwise it just shows the status of the latest CI build, whether or not it was merged. I hardcoded `main` here but maybe there's a template?