### PR TITLE
Two modifications to the templates for GitHub Actions CI

### DIFF
--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -22,7 +22,7 @@ const EXTRA_VERSIONS_DOC = "- `extra_versions::Vector`: Extra Julia versions to 
         x64=true,
         x86=false,
         coverage=true,
-        extra_versions=$DEFAULT_CI_VERSIONS,
+        extra_versions=$DEFAULT_CI_VERSIONS_NO_NIGHTLY,
     )
 
 Integrates your packages with [GitHub Actions](https://github.com/features/actions).
@@ -53,7 +53,7 @@ $EXTRA_VERSIONS_DOC
     x64::Bool = true
     x86::Bool = false
     coverage::Bool = true
-    extra_versions::Vector = DEFAULT_CI_VERSIONS
+    extra_versions::Vector = DEFAULT_CI_VERSIONS_NO_NIGHTLY
 end
 
 source(p::GitHubActions) = p.file

--- a/templates/github/workflows/CI-julia-nightly.yml
+++ b/templates/github/workflows/CI-julia-nightly.yml
@@ -1,18 +1,16 @@
-name: CI
+name: CI (Julia nightly)
 on:
   - push
   - pull_request
 jobs:
-  test:
+  test-julia-nightly:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
-          <<#VERSIONS>>
-          - '<<&.>>'
-          <</VERSIONS>>
+          - 'nightly'
         os:
           <<#OS>>
           - <<&.>>
@@ -61,43 +59,4 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       <</HAS_COVERALLS>>
   <<#HAS_DOCUMENTER>>
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-  doctests:
-    name: Doctests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: |
-          julia --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using <<&PKG>>
-            DocMeta.setdocmeta!(<<&PKG>>, :DocTestSetup, :(using <<&PKG>>); recursive=true)
-            doctest(<<&PKG>>)'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
   <</HAS_DOCUMENTER>>


### PR DESCRIPTION
This pull request makes two modifications to the templates for GitHub Actions CI. These modifications are motivated by feedback that I have observed from various users.

### 1. Separate the single `docs` job into two separate jobs for (1) running the doctests and (2) building and deploying the docs

There are many reasons why doctests might be failing. For example, between Julia 1.5 and 1.6, there have been several changes to printing (e.g. something that is printed like `Array{Int64,1}` in Julia 1.5 is printed like `Vector{Int64} (alias for Array{Int64, 1})` in Julia 1.6). Therefore, it is very reasonable for users to want their docs to build and deploy even if their doctests are failing.

Currently, we do everything in a single `docs` job that runs the doctests prior to building and deploying the docs. Therefore, if the doctests fail, the docs are not built.

With this PR, the docs are built and deployed in the `docs` job, and the doctests are run in the `doctests` job. The docs will be built and deployed even if the doctests fail.

### 2. Move the tests on Julia nightly into a separate workflow file, which allows the user to generate separate README badges for `CI` versus `CI (Julia nightly)`

Many users have asked if GitHub Actions has a option analogous to this feature in Travis CI:
```yaml
allow_failures:
  - julia: nightly
```

Unfortunately, GitHub Actions does not have an analogous feature. There are several alternatives, but none of them are good:
1. Use `continue-on-error`. Unfortunately, if you do this, GitHub Actions will make it look like your CI is always passing on Julia nightly. But this is not what people want. People want to know whether or not their CI passes on Julia nightly, but they don't want failures on Julia nightly to make their overall README CI badge status be "failing".
2. Don't test on Julia nightly. This is not an option for many people.
3. The current approach. Unfortunately, with the current approach, if your CI is failing on Julia nightly, but passing on all other Julia versions, the CI badge in your README will still say "failing".

This pull request moves the Julia nightly job to a separate CI file. Therefore, the `CI` badge will only apply to non-nightly jobs. There will be a separate `CI (Julia nightly)` badge for the nightly jobs.