### PR TITLE
some changes to allow for more customization of badges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.14"
+version = "0.7.15"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -4,7 +4,6 @@ const DOCUMENTER_DEP = PackageSpec(;
 )
 
 struct NoDeploy end
-const DeployStyle = Union{TravisCI, GitHubActions, GitLabCI, NoDeploy}
 const YesDeploy = Union{TravisCI, GitHubActions, GitLabCI}
 const GitHubPagesStyle = Union{TravisCI, GitHubActions}
 
@@ -23,7 +22,7 @@ Logo information for documentation.
 end
 
 """
-    Documenter{T<:Union{TravisCI, GitLabCI, GitHubActions, NoDeploy}}(;
+    Documenter{T}(;
         make_jl="$(contractuser(default_file("docs", "make.jl")))",
         index_md="$(contractuser(default_file("docs", "src", "index.md")))",
         assets=String[],
@@ -61,7 +60,7 @@ or `Nothing` to only support local documentation builds.
     If deploying documentation with Travis CI, don't forget to complete
     [the required configuration](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#SSH-Deploy-Keys-1).
 """
-struct Documenter{T<:DeployStyle} <: Plugin
+struct Documenter{T} <: Plugin
     assets::Vector{String}
     logo::Logo
     makedocs_kwargs::Dict{Symbol}
@@ -80,7 +79,7 @@ function Documenter{T}(;
     make_jl::AbstractString=default_file("docs", "make.jl"),
     index_md::AbstractString=default_file("docs", "src", "index.md"),
     devbranch::Union{String, Nothing}=nothing,
-) where T <: DeployStyle
+) where {T}
     return Documenter{T}(
         assets,
         logo,

--- a/src/plugins/readme.jl
+++ b/src/plugins/readme.jl
@@ -17,6 +17,7 @@ Creates a `README` file that contains badges for other included plugins.
     file::String = default_file("README.md")
     destination::String = "README.md"
     inline_badges::Bool = false
+    badge_order::Vector{DataType} = default_badge_order()
 end
 
 source(p::Readme) = p.file
@@ -26,7 +27,7 @@ function view(p::Readme, t::Template, pkg::AbstractString)
     # Explicitly ordered badges go first.
     strings = String[]
     done = DataType[]
-    foreach(badge_order()) do T
+    foreach(p.badge_order) do T
         if hasplugin(t, T)
             append!(strings, badges(getplugin(t, T), t, pkg))
             push!(done, T)
@@ -45,7 +46,7 @@ function view(p::Readme, t::Template, pkg::AbstractString)
     )
 end
 
-badge_order() = [
+default_badge_order() = [
     Documenter{GitHubActions},
     Documenter{GitLabCI},
     Documenter{TravisCI},

--- a/test/show.jl
+++ b/test/show.jl
@@ -19,6 +19,7 @@ end
               file: "$(joinpath(TEMPLATES_DIR, "README.md"))"
               destination: "README.md"
               inline_badges: false
+              badge_order: DataType[Documenter{GitHubActions}, Documenter{GitLabCI}, Documenter{TravisCI}, GitHubActions, GitLabCI, TravisCI, AppVeyor, DroneCI, CirrusCI, Codecov, Coveralls, BlueStyleBadge, ColPracBadge]
             """
         test_show(rstrip(expected), sprint(show, MIME("text/plain"), Readme()))
     end

--- a/test/show.jl
+++ b/test/show.jl
@@ -55,6 +55,7 @@ end
                   file: "$(joinpath(TEMPLATES_DIR, "README.md"))"
                   destination: "README.md"
                   inline_badges: false
+                  badge_order: DataType[Documenter{GitHubActions}, Documenter{GitLabCI}, Documenter{TravisCI}, GitHubActions, GitLabCI, TravisCI, AppVeyor, DroneCI, CirrusCI, Codecov, Coveralls, BlueStyleBadge, ColPracBadge]
                 SrcDir:
                   file: "$(joinpath(TEMPLATES_DIR, "src", "module.jl"))"
                 TagBot:


### PR DESCRIPTION
This PR includes a couple of small changes to make plugins more easily customizable, particularly the printing of badges in the README.

First, I have dropped the restriction to `DeployStyle` from the type parameter of `Documenter`.  The reason for this is that, as `DeployStyle` is a type union, a user cannot create a new plugin type and provide it as a type parameter to `Documenter`.  This is needed to, e.g. change the badges returned by the `Documenter` plugin.

Next, I have added the `badge_order::Vector{DataType}` field to the `Readme` struct.  This allows users to set their own badge order.  The original default order remains the default, but I have changed the name of the function that creates this order to `default_badge_order` for clarity.

I don't think there should be any test errors here on 1.5, but I worked on this on 1.6 in which I get some rather inscrutable Cassette (via SimpleMock) errors when testing.  Hopefully there will be no errors in the automated unit tests, but if there are, I'll probably have to look into the Cassette errors before this goes anywhere.

Thanks!