### PR TITLE
Change GitHubActions badge to match action filename

### DIFF
--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -60,9 +60,9 @@ source(p::GitHubActions) = p.file
 destination(p::GitHubActions) = joinpath(".github", "workflows", p.destination)
 tags(::GitHubActions) = "<<", ">>"
 
-badges(::GitHubActions) = Badge(
+badges(p::GitHubActions) = Badge(
     "Build Status",
-    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/workflows/CI/badge.svg",
+    "https://github.com/{{{USER}}}/{{{PKG}}}.jl/workflows/$(first(splitext(p.destination)))/badge.svg",
     "https://github.com/{{{USER}}}/{{{PKG}}}.jl/actions",
 )
 


### PR DESCRIPTION
This changes the badge to depend on the action name, to allow multiple CI actions e.g.
```julia
GihubActions()  # CI 
GithubActions(file=default("JuliaNightly.yml"), destination="JuliaNightly.yml)  # CI on 'nightly' version of Julia 
```
and have a badge for each, like https://github.com/invenia/nameddims.jl/workflows/CI/badge.svg and https://github.com/invenia/nameddims.jl/workflows/JuliaNightly/badge.svg

Questions:
- Do we also need to change the link to `https://github.com/{{{USER}}}/{{{PKG}}}.jl/actions?query=workflow:name`? e.g. so the `JuliaNightly` badge would go to e.g. https://github.com/Invenia/NamedDims.jl/actions?query=workflow:JuliaNightly
- Where/how is best to add a test for this?

(Kinda related to #246 / #247 )