### PR TITLE
Fix Documenter plugin sort bug

### DIFF
--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -128,7 +128,7 @@ view(p::Documenter, t::Template, pkg::AbstractString) = Dict(
     "AUTHORS" => join(t.authors, ", "),
     "CANONICAL" => p.canonical_url === nothing ? nothing : p.canonical_url(t, pkg),
     "HAS_ASSETS" => !isempty(p.assets),
-    "MAKEDOCS_KWARGS" => map(((k, v),) -> k => repr(v), sort(collect(p.makedocs_kwargs))),
+    "MAKEDOCS_KWARGS" => map(((k, v),) -> k => repr(v), sort(collect(p.makedocs_kwargs), by=first)),
     "PKG" => pkg,
     "REPO" => "$(t.host)/$(t.user)/$pkg.jl",
     "USER" => t.user,

--- a/test/plugin.jl
+++ b/test/plugin.jl
@@ -94,7 +94,7 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
         # A failure looks like: `MethodError: no method matching isless(::Symbol, ::Bool)`
         with_pkg(t) do pkg
             pkg_dir = joinpath(t.dir, pkg)
-            @test isdir(joinpath(pkg_dir), "docs")
+            @test isdir(joinpath(pkg_dir, "docs"))
         end
     end
 end

--- a/test/plugin.jl
+++ b/test/plugin.jl
@@ -86,4 +86,15 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
             end
         end
     end
+
+    # https://github.com/invenia/PkgTemplates.jl/issues/275
+    @testset "makedocs_kwargs sort bug" begin
+        p = Documenter(; makedocs_kwargs=Dict(:strict => true, :checkdocs => :exports))
+        t = tpl(; plugins=[p])
+        # A failure looks like: `MethodError: no method matching isless(::Symbol, ::Bool)`
+        with_pkg(t) do pkg
+            pkg_dir = joinpath(t.dir, pkg)
+            @test isdir(joinpath(pkg_dir), "docs")
+        end
+    end
 end


### PR DESCRIPTION
Fixes this bug we noticed with our package template extensions:
```
MethodError: no method matching isless(::Symbol, ::Bool)
  Closest candidates are:
    isless(!Matched::Missing, ::Any) at missing.jl:87
    isless(::Symbol, !Matched::Symbol) at strings/basic.jl:341
    isless(!Matched::AbstractFloat, ::Real) at operators.jl:167
    ...
  Stacktrace:
   [1] isless(::Pair{Symbol,Any}, ::Pair{Symbol,Any}) at ./pair.jl:57
   [2] lt at ./ordering.jl:57 [inlined]
   [3] sort!(::Array{Pair{Symbol,Any},1}, ::Int64, ::Int64, ::Base.Sort.InsertionSortAlg, ::Base.Order.ForwardOrdering) at ./sort.jl:498
   [4] sort!(::Array{Pair{Symbol,Any},1}, ::Int64, ::Int64, ::Base.Sort.MergeSortAlg, ::Base.Order.ForwardOrdering, ::Array{Pair{Symbol,Any},1}) at ./sort.jl:583
   [5] sort! at ./sort.jl:582 [inlined]
   [6] sort! at ./sort.jl:673 [inlined]
   [7] #sort!#7 at ./sort.jl:733 [inlined]
   [8] sort! at ./sort.jl:721 [inlined]
   [9] sort(::Array{Pair{Symbol,Any},1}; kws::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./sort.jl:780
   [10] sort(::Array{Pair{Symbol,Any},1}) at ./sort.jl:780
   [11] view(::Documenter{GitHubActions}, ::Template, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugins/documenter.jl:126
   [12] view(::Documenter{GitHubActions}, ::Template, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugins/documenter.jl:139
   [13] combined_view(::Documenter{GitHubActions}, ::Template, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugin.jl:151
   [14] (::PkgTemplates.var"#39#40"{Documenter{GitHubActions},Template,String})(::PkgTemplates.Badge) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugin.jl:237
   [15] iterate at ./generator.jl:47 [inlined]
   [16] _collect(::Array{PkgTemplates.Badge,1}, ::Base.Generator{Array{PkgTemplates.Badge,1},PkgTemplates.var"#39#40"{Documenter{GitHubActions},Template,String}}, ::Base.EltypeUnknown, ::Base.HasShape{1}) at ./array.jl:699
   [17] collect_similar at ./array.jl:628 [inlined]
   [18] map at ./abstractarray.jl:2162 [inlined]
   [19] badges(::Documenter{GitHubActions}, ::Template, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugin.jl:237
   [20] (::PkgTemplates.var"#59#61"{Readme,Template,String,Array{String,1},Array{DataType,1}})(::Type{T} where T) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugins/readme.jl:35
   [21] foreach at ./abstractarray.jl:2009 [inlined]
   [22] view(::Readme, ::Template, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugins/readme.jl:33
   [23] combined_view(::Readme, ::Template, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugin.jl:151
   [24] render_plugin(::Readme, ::Template, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugin.jl:303
   [25] hook at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/plugin.jl:298 [inlined]
   [26] (::PkgTemplates.var"#17#20"{typeof(PkgTemplates.hook),Template,String})(::Readme) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/template.jl:132
   [27] foreach(::PkgTemplates.var"#17#20"{typeof(PkgTemplates.hook),Template,String}, ::Array{Plugin,1}) at ./abstractarray.jl:2009
   [28] (::PkgTemplates.var"#16#19"{Template,String})(::typeof(PkgTemplates.hook)) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/template.jl:131
   [29] foreach(::PkgTemplates.var"#16#19"{Template,String}, ::Tuple{typeof(PkgTemplates.prehook),typeof(PkgTemplates.hook),typeof(PkgTemplates.posthook)}) at ./abstractarray.jl:2009
   [30] (::Template)(::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/PkgTemplates/6jeQX/src/template.jl:129
   [31] macro expansion at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl.tmp/depot/packages/Suppressor/nTjgZ/src/Suppressor.jl:35 [inlined]
   [32] (::var"#5#10"{var"#15#20",typeof(research_public_template),String})(::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/runtests.jl:18
   [33] mktempdir(::var"#5#10"{var"#15#20",typeof(research_public_template),String}, ::String; prefix::String) at ./file.jl:709
   [34] mktempdir(::Function, ::String) at ./file.jl:707 (repeats 2 times)
   [35] with_pkgs(::var"#15#20", ::Function, ::String) at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/runtests.jl:15
   [36] top-level scope at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/all_templates.jl:22
   [37] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:1115
   [38] top-level scope at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/all_templates.jl:22
   [39] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:1190
   [40] top-level scope at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/all_templates.jl:2
   [41] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:1115
   [42] top-level scope at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/all_templates.jl:2
   [43] include(::String) at ./client.jl:457
   [44] top-level scope at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/runtests.jl:25
   [45] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:1115
   [46] top-level scope at /Users/admin/builds/f75a2375/0/invenia/InveniaTemplates.jl/test/runtests.jl:25
   [47] include(::String) at ./client.jl:457
   [48] top-level scope at none:6
   [49] eval(::Module, ::Any) at ./boot.jl:331
   [50] exec_options(::Base.JLOptions) at ./client.jl:272

```
I'll try to make a testcase here to stop this from occurring in the future