### PR TITLE
don't use PkgServers in Documenter job

### DIFF
--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -74,6 +74,8 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
+        env:
+          JULIA_PKG_SERVER: ""
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -48,6 +48,8 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
+        env:
+          JULIA_PKG_SERVER: ""
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest


### PR DESCRIPTION
The version of the registry served by PkgServers can sometimes lag a
little bit behind, leading to issues such as in JuliaDiff/FiniteDifferences.jl#173.
The `julia-buildpkg` action actually already does this here:
https://github.com/julia-actions/julia-buildpkg/blob/1b0a69ab74709d3707f86249fce805049212961a/action.yml#L22