### PR TITLE
use `julia-docdeploy` action

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.18"
+version = "0.7.19"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -375,8 +375,8 @@ Here are some testing tips to ensure that your PR goes through as smoothly as po
 ### Updating Reference Tests & Fixtures
 
 If you've added or modified plugins, you should update the reference tests and the associated test fixtures.
-In `test/reference.jl`, you'll find a "Reference tests" test set that basically generates a bunch of packages, and then checks each file against a reference file, which is stored somewhere in `test/fixtures`. Note the reference tests only run on one specific version of Julia; check `test/runtests.jl`
-to see the current version used.
+In `test/reference.jl`, you'll find a "Reference tests" test set that basically generates a bunch of packages, and then checks each file against a reference file, which is stored somewhere in `test/fixtures`. 
+Note the reference tests only run on one specific version of Julia; check `test/runtests.jl` to see the current version used.
 
 For new plugins, you should add an instance of your plugin to the "All plugins" and "Wacky options" test sets, then run the tests with `Pkg.test`.
 They should pass, and there will be new files in `test/fixtures`.

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -375,7 +375,8 @@ Here are some testing tips to ensure that your PR goes through as smoothly as po
 ### Updating Reference Tests & Fixtures
 
 If you've added or modified plugins, you should update the reference tests and the associated test fixtures.
-In `test/reference.jl`, you'll find a "Reference tests" test set that basically generates a bunch of packages, and then checks each file against a reference file, which is stored somewhere in `test/fixtures`.
+In `test/reference.jl`, you'll find a "Reference tests" test set that basically generates a bunch of packages, and then checks each file against a reference file, which is stored somewhere in `test/fixtures`. Note the reference tests only run on one specific version of Julia; check `test/runtests.jl`
+to see the current version used.
 
 For new plugins, you should add an instance of your plugin to the "All plugins" and "Wacky options" test sets, then run the tests with `Pkg.test`.
 They should pass, and there will be new files in `test/fixtures`.

--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -69,8 +69,8 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -69,20 +69,15 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest
             using <<&PKG>>
             DocMeta.setdocmeta!(<<&PKG>>, :DocTestSetup, :(using <<&PKG>>); recursive=true)
             doctest(<<&PKG>>)'
-      - run: julia --project=docs docs/make.jl
-        env:
-          JULIA_PKG_SERVER: ""
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
   <</HAS_DOCUMENTER>>

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -43,19 +43,14 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest
             using DocumenterGitHubActions
             DocMeta.setdocmeta!(DocumenterGitHubActions, :DocTestSetup, :(using DocumenterGitHubActions); recursive=true)
             doctest(DocumenterGitHubActions)'
-      - run: julia --project=docs docs/make.jl
-        env:
-          JULIA_PKG_SERVER: ""
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -43,19 +43,14 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest
             using WackyOptions
             DocMeta.setdocmeta!(WackyOptions, :DocTestSetup, :(using WackyOptions); recursive=true)
             doctest(WackyOptions)'
-      - run: julia --project=docs docs/make.jl
-        env:
-          JULIA_PKG_SERVER: ""
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This switches the default GHA + Documenter config to use the julia-docdeploy action in order to take advantage of the new in-line annotation feature: https://github.com/julia-actions/julia-docdeploy/releases/tag/v1.2.0.

Uses `buildpkg` to build while avoiding the package server (and also to follow the julia-docdeploy README example).