### PR TITLE
Set `permissions: contents: write`

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,10 +6,13 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,12 +6,10 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
-    permissions: write-all
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.26"
+version = "0.7.27"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -65,6 +65,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -65,7 +65,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -75,7 +76,6 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest

--- a/templates/github/workflows/register.yml
+++ b/templates/github/workflows/register.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   register:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: julia-actions/RegisterAction@latest
         with:

--- a/templates/github/workflows/register.yml
+++ b/templates/github/workflows/register.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   register:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+        contents: write
     steps:
       - uses: julia-actions/RegisterAction@latest
         with:

--- a/test/fixtures/AllPlugins/.github/workflows/register.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/register.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   register:
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
     steps:
       - uses: julia-actions/RegisterAction@latest
         with:

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -37,6 +37,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -46,7 +48,6 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -37,6 +37,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -46,7 +48,6 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest

--- a/test/fixtures/WackyOptions/.github/workflows/register.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/register.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   register:
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
     steps:
       - uses: julia-actions/RegisterAction@latest
         with:


### PR DESCRIPTION
Setting `permissions: contents: write` is required in new repositories for the `GITHUB_TOKEN` to work. See also https://github.com/JuliaDocs/Documenter.jl/pull/1819 and https://github.com/julia-actions/julia-docdeploy/pull/21

Without it, people might get an error like
```
fatal: unable to access 'https://github.com/rikhuijzer/MyProject.jl.git/': The requested URL returned error: 403
```

Please double-check whether I haven't missed a place in PkgTemplates.jl where this setting should be set too