### PR TITLE
Allow setting Documenter `edit_link`

### DIFF
--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -93,8 +93,10 @@ function convert_input(P::Type, ::Type{Union{T, Nothing}}, s::AbstractString) wh
 end
 
 function convert_input(P::Type, ::Type{Union{T, Symbol, Nothing}}, s::AbstractString) where T
-    return if startswith(s, ":") || startswith(s, "Symbol(\"")
-        Symbol(s)
+    # Assume inputs starting with ':' char are intended as Symbols, if a plugin accept symbols.
+    # i.e. assume the set of valid Symbols the plugin expects can be spelt starting with ':'.
+    return if startswith(s, ":")
+        Symbol(s[2:end])  # skip ':'
     else
         convert_input(P, Union{T,Nothing}, s)
     end

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -96,7 +96,7 @@ function convert_input(P::Type, ::Type{Union{T, Symbol, Nothing}}, s::AbstractSt
     # Assume inputs starting with ':' char are intended as Symbols, if a plugin accept symbols.
     # i.e. assume the set of valid Symbols the plugin expects can be spelt starting with ':'.
     return if startswith(s, ":")
-        Symbol(s[2:end])  # skip ':'
+        Symbol(chop(s, head=1, tail=0))  # remove ':'
     else
         convert_input(P, Union{T,Nothing}, s)
     end

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -92,6 +92,14 @@ function convert_input(P::Type, ::Type{Union{T, Nothing}}, s::AbstractString) wh
     return s == "nothing" ? nothing : convert_input(P, T, s)
 end
 
+function convert_input(P::Type, ::Type{Union{T, Symbol, Nothing}}, s::AbstractString) where T
+    return if startswith(s, ":") || startswith(s, "Symbol(\"")
+        Symbol(s)
+    else
+        convert_input(P, Union{T,Nothing}, s)
+    end
+end
+
 function convert_input(::Type, ::Type{Bool}, s::AbstractString)
     s = lowercase(s)
     return if startswith(s, 't') || startswith(s, 'y')

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -28,7 +28,9 @@ end
         assets=String[],
         logo=Logo(),
         canonical_url=make_canonical(T),
-        makedocs_kwargs=Dict{Symbol, Any}(),
+        devbranch=nothing,
+        edit_link=:devbranch,
+        makedocs_kwargs=Dict{Symbol,Any}(),
     )
 
 Sets up documentation generation via [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl).
@@ -53,8 +55,13 @@ or `Nothing` to only support local documentation builds.
   The default value will compute GitHub Pages and GitLab Pages URLs
   for [`TravisCI`](@ref) and [`GitLabCI`](@ref), respectively.
   If set to `nothing`, no canonical URL is set.
-- `makedocs_kwargs::Dict{Symbol}`: Extra keyword arguments to be inserted into `makedocs`.
+- `edit_link::Union{AbstractString, Symbol, Nothing}`: Branch, tag or commit that the
+  "Edit on…" link will point to. Defaults to the branch identified by `devbranch`.
+  If `edit_link=:commit`, then the link will point to the latest commit when docs are built.
+  If `edit_link=nothing`, then the "Edit on…" link will be hidden altogether.
 - `devbranch::Union{AbstractString, Nothing}`: Branch that will trigger docs deployment.
+  If `nothing`, then the default branch according to the `Template` will be used.
+- `makedocs_kwargs::Dict{Symbol,Any}`: Extra keyword arguments to be inserted into `makedocs`.
 
 !!! note
     If deploying documentation with Travis CI, don't forget to complete
@@ -68,6 +75,7 @@ struct Documenter{T} <: Plugin
     make_jl::String
     index_md::String
     devbranch::Union{String, Nothing}
+    edit_link::Union{String, Symbol, Nothing}
 end
 
 # Can't use @plugin because we're implementing our own no-arguments constructor.
@@ -78,7 +86,8 @@ function Documenter{T}(;
     canonical_url::Union{Function, Nothing}=make_canonical(T),
     make_jl::AbstractString=default_file("docs", "make.jl"),
     index_md::AbstractString=default_file("docs", "src", "index.md"),
-    devbranch::Union{String, Nothing}=nothing,
+    devbranch::Union{AbstractString, Nothing}=nothing,
+    edit_link::Union{AbstractString, Symbol, Nothing}=:devbranch,
 ) where {T}
     return Documenter{T}(
         assets,
@@ -88,6 +97,7 @@ function Documenter{T}(;
         make_jl,
         index_md,
         devbranch,
+        edit_link,
     )
 end
 
@@ -99,6 +109,7 @@ defaultkw(::Type{<:Documenter}, ::Val{:logo}) = Logo()
 defaultkw(::Type{<:Documenter}, ::Val{:make_jl}) = default_file("docs", "make.jl")
 defaultkw(::Type{<:Documenter}, ::Val{:index_md}) = default_file("docs", "src", "index.md")
 defaultkw(::Type{<:Documenter}, ::Val{:devbranch}) = nothing
+defaultkw(::Type{<:Documenter}, ::Val{:edit_link}) = :devbranch
 
 gitignore(::Documenter) = ["/docs/build/"]
 priority(::Documenter, ::Function) = DEFAULT_PRIORITY - 1  # We need SrcDir to go first.
@@ -123,17 +134,25 @@ badges(::Documenter{GitLabCI}) = Badge(
     "https://{{{USER}}}.gitlab.io/{{{PKG}}}.jl/dev",
 )
 
-view(p::Documenter, t::Template, pkg::AbstractString) = Dict(
-    "ASSETS" => map(basename, p.assets),
-    "AUTHORS" => join(t.authors, ", "),
-    "CANONICAL" => p.canonical_url === nothing ? nothing : p.canonical_url(t, pkg),
-    "HAS_ASSETS" => !isempty(p.assets),
-    "MAKEDOCS_KWARGS" => map(((k, v),) -> k => repr(v), sort(collect(p.makedocs_kwargs), by=first)),
-    "PKG" => pkg,
-    "REPO" => "$(t.host)/$(t.user)/$pkg.jl",
-    "USER" => t.user,
-    "BRANCH" => p.devbranch === nothing ? default_branch(t) : p.devbranch,
-)
+function view(p::Documenter, t::Template, pkg::AbstractString)
+    devbranch = p.devbranch === nothing ? default_branch(t) : p.devbranch
+    return Dict(
+        "ASSETS" => map(basename, p.assets),
+        "AUTHORS" => join(t.authors, ", "),
+        "CANONICAL" => p.canonical_url === nothing ? nothing : p.canonical_url(t, pkg),
+        "HAS_ASSETS" => !isempty(p.assets),
+        "MAKEDOCS_KWARGS" => map(((k, v),) -> k => repr(v), sort(collect(p.makedocs_kwargs), by=first)),
+        "PKG" => pkg,
+        "REPO" => "$(t.host)/$(t.user)/$pkg.jl",
+        "USER" => t.user,
+        "BRANCH" => devbranch,
+        "EDIT_LINK" => p.edit_link == :devbranch ? _quoted(devbranch) : _quoted(p.edit_link),
+    )
+end
+
+# So both Symbol and Strings get interpolated correctly into `{{{s}}}`.
+_quoted(s::AbstractString) = string('"', s, '"')
+_quoted(s::Symbol) = repr(s)
 
 function view(p::Documenter{<:GitHubPagesStyle}, t::Template, pkg::AbstractString)
     base = invoke(view, Tuple{Documenter, Template, AbstractString}, p, t, pkg)

--- a/templates/docs/make.jl
+++ b/templates/docs/make.jl
@@ -13,6 +13,9 @@ makedocs(;
 {{#CANONICAL}}
         canonical="{{{CANONICAL}}}",
 {{/CANONICAL}}
+{{#EDIT_LINK}}
+        edit_link={{{EDIT_LINK}}},
+{{/EDIT_LINK}}
         assets={{^HAS_ASSETS}}String{{/HAS_ASSETS}}[{{^HAS_ASSETS}}],{{/HAS_ASSETS}}
 {{#ASSETS}}
             "assets/{{{.}}}",

--- a/test/fixtures/AllPlugins/docs/make.jl
+++ b/test/fixtures/AllPlugins/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(;
     sitename="AllPlugins.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
+        edit_link="main",
         assets=String[],
     ),
     pages=[

--- a/test/fixtures/DocumenterGitHubActions/docs/make.jl
+++ b/test/fixtures/DocumenterGitHubActions/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(;
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://tester.github.io/DocumenterGitHubActions.jl",
+        edit_link="main",
         assets=String[],
     ),
     pages=[

--- a/test/fixtures/DocumenterGitLabCI/docs/make.jl
+++ b/test/fixtures/DocumenterGitLabCI/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(;
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://tester.gitlab.io/DocumenterGitLabCI.jl",
+        edit_link="main",
         assets=String[],
     ),
     pages=[

--- a/test/fixtures/DocumenterTravis/docs/make.jl
+++ b/test/fixtures/DocumenterTravis/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(;
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://tester.github.io/DocumenterTravis.jl",
+        edit_link="main",
         assets=String[],
     ),
     pages=[

--- a/test/fixtures/WackyOptions/docs/make.jl
+++ b/test/fixtures/WackyOptions/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(;
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="http://example.com",
+        edit_link=:commit,
         assets=[
             "assets/static.txt",
         ],

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -169,10 +169,12 @@ end
             print(
                 stdin.buffer,
                 DOWN^2, CR,        # Select GitLabCI
-                DOWN^3, CR, DONE,  # Customize index_md
+                DOWN^2, CR,        # Customize edit_link
+                DOWN, CR, DONE,    # Customize index_md
+                ":commit", LF,     # Enter edit_link
                 "x.txt", LF,       # Enter index file
             )
-            @test PT.interactive(Documenter) == Documenter{GitLabCI}(; index_md="x.txt")
+            @test PT.interactive(Documenter) == Documenter{GitLabCI}(; edit_link=:commit, index_md="x.txt")
 
             print(
                 stdin.buffer,

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -169,7 +169,7 @@ end
             print(
                 stdin.buffer,
                 DOWN^2, CR,        # Select GitLabCI
-                DOWN^2, CR, DONE,  # Customize index_md
+                DOWN^3, CR, DONE,  # Customize index_md
                 "x.txt", LF,       # Enter index file
             )
             @test PT.interactive(Documenter) == Documenter{GitLabCI}(; index_md="x.txt")

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -125,6 +125,7 @@ end
                 makedocs_kwargs=Dict(:foo => "bar", :bar => "baz"),
                 canonical_url=(_t, _pkg) -> "http://example.com",
                 devbranch="foobar",
+                edit_link=:commit,
             ),
             DroneCI(; amd64=false, arm=true, arm64=true, extra_versions=["1.3"]),
             Git(; ignore=["a", "b", "c"], manifest=true, branch="whackybranch"),


### PR DESCRIPTION
- close #348 
- Adds support for `edit_link` which was added in Documenter v0.24 (previously there was `edit_branch`) https://github.com/JuliaDocs/Documenter.jl/pull/1173
- since `edit_link=nothing` has a meaning in Documenter, we use `edit_link=:devbranch` to mean "do the obvious thing" which i think it is uncontroversial to say is "point at the main development branch" which we take from the `devbranch=...` keyword (which in turn fallsback to `default_branch(::Template)`)
  - also adds support for users passing Symbols, both so we can use `:devbranch` as the default and because Documenter allows Symbols (specifically [the Symbol `:commit` has a special meaning](https://github.com/JuliaDocs/Documenter.jl/blob/8986c4d6e1b58ffc009f8b3733fc57520f4a73a9/src/Writers/HTMLWriter.jl#L307-L311))

cc @gdalle 

