### PR TITLE
Improve display of tips and defaults in interactive prompt 

### DIFF
--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -138,7 +138,7 @@ prompt(P::Type, T::Type, name::Symbol) = prompt(P, T, Val(name))
 # The trailing `nothing` is a hack for `fallback_prompt` to use, ignore it.
 function prompt(P::Type, ::Type{T}, ::Val{name}, ::Nothing=nothing) where {T, name}
     default = defaultkw(P, name)
-    tips = join([input_tips(T); "default=$(input_string(default))"], ", ")
+    tips = join([input_tips(T); "default: $(input_string(default))"], ", ")
     input = Base.prompt(pretty_message("Enter value for '$name' ($tips)"))
     input === nothing && throw(InterruptException())
     input = strip(input, '"')

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -122,6 +122,11 @@ function convert_input(P::Type, T::Type{<:Vector}, s::AbstractString)
     return map(x -> convert_input(P, eltype(T), x), xs)
 end
 
+# how would the user type `x` in interactive mode?
+input_string(x) = string(x)
+input_string(x::AbstractString) = isempty(x) ? repr(x) : String(x)
+input_string(x::Symbol) = repr(x)
+
 """
     prompt(::Type{P}, ::Type{T}, ::Val{name::Symbol}) -> Any
 
@@ -132,8 +137,8 @@ prompt(P::Type, T::Type, name::Symbol) = prompt(P, T, Val(name))
 
 # The trailing `nothing` is a hack for `fallback_prompt` to use, ignore it.
 function prompt(P::Type, ::Type{T}, ::Val{name}, ::Nothing=nothing) where {T, name}
-    tips = join([input_tips(T); "default=$(repr(defaultkw(P, name)))"], ", ")
     default = defaultkw(P, name)
+    tips = join([input_tips(T); "default=$(input_string(default))"], ", ")
     input = Base.prompt(pretty_message("Enter value for '$name' ($tips)"))
     input === nothing && throw(InterruptException())
     input = strip(input, '"')

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -69,11 +69,14 @@ end
 Provide some extra tips to users on how to structure their input for the type `T`,
 for example if multiple delimited values are expected.
 """
-input_tips(::Type{Vector{T}}) where T = ["comma-delimited", input_tips(T)...]
-input_tips(::Type{Nothing}) = String[]
-input_tips(::Type{Union{T, Nothing}}) where T = ["'nothing' for nothing", input_tips(T)...]
+input_tips(::Type{Vector{T}}) where T = [input_tips(T)..., "comma-delimited"]
+input_tips(::Type{Union{T, Nothing}}) where T = [input_tips(T)..., input_tips(Nothing)...]
+input_tips(::Type{Nothing}) = ["'nothing' for nothing"]
 input_tips(::Type{Secret}) = ["name only"]
-input_tips(::Type) = String[]
+# Show expected input type as a tip if it's anything other than `String`
+input_tips(::Type{T}) where T = String[string(T)]
+input_tips(::Type{String}) = String[]
+input_tips(::Type{<:Signed}) = ["Int"]  # Specific Int type likely not important
 
 """
     convert_input(::Type{P}, ::Type{T}, s::AbstractString) -> T
@@ -129,7 +132,7 @@ prompt(P::Type, T::Type, name::Symbol) = prompt(P, T, Val(name))
 
 # The trailing `nothing` is a hack for `fallback_prompt` to use, ignore it.
 function prompt(P::Type, ::Type{T}, ::Val{name}, ::Nothing=nothing) where {T, name}
-    tips = join([T; input_tips(T); "default=$(repr(defaultkw(P, name)))"], ", ")
+    tips = join([input_tips(T); "default=$(repr(defaultkw(P, name)))"], ", ")
     default = defaultkw(P, name)
     input = Base.prompt(pretty_message("Enter value for '$name' ($tips)"))
     input === nothing && throw(InterruptException())

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -232,7 +232,7 @@ function interactive(::Type{Documenter})
 end
 
 function prompt(::Type{<:Documenter}, ::Type{Logo}, ::Val{:logo})
-    light = Base.prompt("Enter value for 'logo.light' (default=nothing)")
-    dark = Base.prompt("Enter value for 'logo.dark' (default=nothing)")
+    light = Base.prompt("Enter value for 'logo.light' (default: nothing)")
+    dark = Base.prompt("Enter value for 'logo.dark' (default: nothing)")
     return Logo(; light=light, dark=dark)
 end

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -232,7 +232,7 @@ function interactive(::Type{Documenter})
 end
 
 function prompt(::Type{<:Documenter}, ::Type{Logo}, ::Val{:logo})
-    light = Base.prompt("Enter value for 'logo.light' (String, default=nothing)")
-    dark = Base.prompt("Enter value for 'logo.dark' (String, default=nothing)")
+    light = Base.prompt("Enter value for 'logo.light' (default=nothing)")
+    dark = Base.prompt("Enter value for 'logo.dark' (default=nothing)")
     return Logo(; light=light, dark=dark)
 end

--- a/src/template.jl
+++ b/src/template.jl
@@ -217,7 +217,7 @@ prompt(::Type{Template}, ::Type, ::Val{:pkg}) = Base.prompt("Package name")
 
 function prompt(::Type{Template}, ::Type, ::Val{:user})
     return if isempty(@mock default_user())
-        input = Base.prompt("Enter value for 'user' (String, required)")
+        input = Base.prompt("Enter value for 'user' (required)")
         input === nothing && throw(InterruptException())
         return input
     else

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -47,13 +47,16 @@ end
     end
 
     @testset "input_tips" begin
-        @test isempty(PT.input_tips(Int))
+        @test isempty(PT.input_tips(String))
+        @test PT.input_tips(Int) == ["Int"]
+        @test PT.input_tips(Bool) == ["Bool"]
+        @test PT.input_tips(Symbol) == ["Symbol"]
         @test PT.input_tips(Vector{String}) == ["comma-delimited"]
         @test PT.input_tips(Union{Vector{String}, Nothing}) ==
-            ["'nothing' for nothing", "comma-delimited"]
+            ["comma-delimited", "'nothing' for nothing"]
         @test PT.input_tips(Union{String, Nothing}) == ["'nothing' for nothing"]
         @test PT.input_tips(Union{Vector{Secret}, Nothing}) ==
-            ["'nothing' for nothing", "comma-delimited", "name only"]
+            ["name only", "comma-delimited", "'nothing' for nothing"]
     end
 
     @testset "Interactive name/type pair collection" begin


### PR DESCRIPTION
- aims to close https://github.com/invenia/PkgTemplates.jl/issues/343 
- The first commit removes `String`  from the tips given at the prompt
  -  Where before we had:
    ```Enter value for 'user' (String, required):```
    we would now have just:
    ```Enter value for 'user' (required):```
- The second commit removes the quote marks `"` around default string values show in the prompt, because users don't need to use quotes when entering string values, and the third commit introduces a space to keep things easy to read
  - Where before we had: 
    ```default="CompatHelper.yml"```
    we would would now have:
    ```default: CompatHelper.yml```
  
Together this changes something like
```
Enter value for 'user' (String, default="nickrobinson251"):
```
to now be like
```
Enter value for 'user' (default: nickrobinson251):
```

Other cases, where the required input isn't a String still show the same tips, e.g. we still have prompts like
```
Enter value for 'coverage' (Bool, default: true):
Enter value for 'extra_versions' (comma-delimited, default: ["1.0", "1.7", "nightly"]):
```
