### PR TITLE
gitlab-ci.yml file prefix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.7.29"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
@@ -12,6 +13,7 @@ Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.7.29"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
@@ -13,7 +12,6 @@ Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -303,6 +303,7 @@ See [`Documenter`](@ref) for more information.
 @plugin struct GitLabCI <: FilePlugin
     file::String = default_file("gitlab-ci.yml")
     coverage::Bool = true
+    file_prefix::String = ""
     # Nightly has no Docker image.
     extra_versions::Vector = DEFAULT_CI_VERSIONS_NO_NIGHTLY
 end
@@ -335,6 +336,7 @@ function view(p::GitLabCI, t::Template, pkg::AbstractString)
         "USER" => t.user,
         "VERSION" => format_version(t.julia),
         "VERSIONS" => collect_versions(t, p.extra_versions),
+        "FILE_PREFIX" => p.file_prefix,
     )
 end
 

--- a/templates/gitlab-ci.yml
+++ b/templates/gitlab-ci.yml
@@ -1,3 +1,4 @@
+{{{FILE_PREFIX}}}
 .script:
   script:
     - |

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -130,7 +130,7 @@ end
             DroneCI(; amd64=false, arm=true, arm64=true, extra_versions=["1.3"]),
             Git(; ignore=["a", "b", "c"], manifest=true, branch="whackybranch"),
             GitHubActions(; x86=true, linux=false, coverage=false),
-            GitLabCI(; coverage=false, extra_versions=[v"0.6"]),
+            GitLabCI(; coverage=false, extra_versions=[v"0.6"], file_prefix=""),
             License(; name="ISC"),
             PkgEvalBadge(),
             ProjectFile(; version=v"1"),


### PR DESCRIPTION
Hi,
PkgTemplates.jl suits my needs to generate new projects with CI pipeline perfectly.
However, I need to be able to make further modifications to gitlab-ci.yml files (set variables during package creation).
While a custom template could be created, addressing this directly in PkgTemplates.jl would be 
- extremly straightforward and 
- one would not have to maintain an additional template, beyond what is already in this package.

With this PR, one could exemplarily set the http_proxy using GitLabCI like so:

```
tpl = Template(;
    dir="./",
    host="host.com",
    user="antonhinneck",
    plugins=[Git(), 
    GitLabCI(;coverage=true,
    file_prefix="variables:\n\thttp_proxy: 10.0.0.1\n")]
)

tpl("Pkg.jl")
```

All tests pass. Would this be sensible for the scope of this package?

Best,
Anton
