### PR TITLE
feat: ignore all Manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
-/Manifest.toml
-/test/fixtures/*/test/Manifest.toml
-/docs/Manifest.toml
+/Manifest*.toml
+/test/fixtures/*/test/Manifest*.toml
+/docs/Manifest*.toml

--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -116,7 +116,7 @@ defaultkw(::Type{<:Documenter}, ::Val{:index_md}) = default_file("docs", "src", 
 defaultkw(::Type{<:Documenter}, ::Val{:devbranch}) = nothing
 defaultkw(::Type{<:Documenter}, ::Val{:edit_link}) = :devbranch
 
-gitignore(::Documenter) = ["/docs/build/", "/docs/Manifest.toml"]
+gitignore(::Documenter) = ["/docs/build/", "/docs/Manifest*.toml"]
 priority(::Documenter, ::Function) = DEFAULT_PRIORITY - 1  # We need SrcDir to go first.
 
 badges(::Documenter) = Badge[]

--- a/src/plugins/git.jl
+++ b/src/plugins/git.jl
@@ -87,7 +87,7 @@ end
 function hook(p::Git, t::Template, pkg_dir::AbstractString)
     ignore = mapreduce(gitignore, vcat, t.plugins)
     # Only ignore manifests at the repo root.
-    p.manifest || "Manifest.toml" in ignore || push!(ignore, "/Manifest.toml")
+    p.manifest || "Manifest.toml" in ignore || push!(ignore, "/Manifest*.toml")
     unique!(sort!(ignore))
     gen_file(joinpath(pkg_dir, ".gitignore"), join(ignore, "\n"))
 end

--- a/test/fixtures/AllPlugins/.gitignore
+++ b/test/fixtures/AllPlugins/.gitignore
@@ -1,6 +1,6 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
-/Manifest.toml
-/docs/Manifest.toml
+/Manifest*.toml
+/docs/Manifest*.toml
 /docs/build/

--- a/test/fixtures/Basic/.gitignore
+++ b/test/fixtures/Basic/.gitignore
@@ -1,1 +1,1 @@
-/Manifest.toml
+/Manifest*.toml

--- a/test/fixtures/DocumenterGitHubActions/.gitignore
+++ b/test/fixtures/DocumenterGitHubActions/.gitignore
@@ -1,3 +1,3 @@
-/Manifest.toml
-/docs/Manifest.toml
+/Manifest*.toml
+/docs/Manifest*.toml
 /docs/build/

--- a/test/fixtures/DocumenterGitLabCI/.gitignore
+++ b/test/fixtures/DocumenterGitLabCI/.gitignore
@@ -1,6 +1,6 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
-/Manifest.toml
-/docs/Manifest.toml
+/Manifest*.toml
+/docs/Manifest*.toml
 /docs/build/

--- a/test/fixtures/DocumenterTravis/.gitignore
+++ b/test/fixtures/DocumenterTravis/.gitignore
@@ -1,3 +1,3 @@
-/Manifest.toml
-/docs/Manifest.toml
+/Manifest*.toml
+/docs/Manifest*.toml
 /docs/build/

--- a/test/fixtures/WackyOptions/.gitignore
+++ b/test/fixtures/WackyOptions/.gitignore
@@ -1,7 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
-/docs/Manifest.toml
+/docs/Manifest*.toml
 /docs/build/
 a
 b


### PR DESCRIPTION
Starting with Julia 1.11, version-specific `Manifest.toml` files can exist side-by-side.

Closes #462 