### PR TITLE
Add SciML code style badge

### DIFF
--- a/docs/src/user.md
+++ b/docs/src/user.md
@@ -84,6 +84,7 @@ These plugins will add badges to the README.
 
 ```@docs
 BlueStyleBadge
+SciMLStyleBadge
 ColPracBadge
 PkgEvalBadge
 ```

--- a/src/PkgTemplates.jl
+++ b/src/PkgTemplates.jl
@@ -43,6 +43,7 @@ export
     Readme,
     RegisterAction,
     Runic,
+    SciMLStyleBadge,
     Secret,
     SrcDir,
     TagBot,

--- a/src/plugins/badges.jl
+++ b/src/plugins/badges.jl
@@ -21,6 +21,21 @@ function badges(::BlueStyleBadge)
 end
 
 """
+    SciMLStyleBadge()
+
+Adds a [`SciMLStyle`](https://github.com/SciML/SciMLStyle) badge to the [`Readme`](@ref) file.
+"""
+struct SciMLStyleBadge <: BadgePlugin end
+
+function badges(::SciMLStyleBadge)
+    return Badge(
+        "Code Style: SciML",
+        "https://img.shields.io/badge/code_style-SciML-9558b2.svg",
+        "https://github.com/SciML/SciMLStyle",
+    )
+end
+
+"""
     ColPracBadge()
 
 Adds a [`ColPrac`](https://github.com/SciML/ColPrac) badge to the [`Readme`](@ref) file.

--- a/test/plugin.jl
+++ b/test/plugin.jl
@@ -75,6 +75,7 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
         end
         @testset "$BadgeType" for (BadgeType, text) in (
             BlueStyleBadge => "BlueStyle",
+            SciMLStyleBadge => "SciMLStyle",
             ColPracBadge => "ColPrac",
             PkgEvalBadge => "PkgEval",
         )

--- a/test/show.jl
+++ b/test/show.jl
@@ -19,7 +19,7 @@ end
               file: "$(joinpath(TEMPLATES_DIR, "README.md"))"
               destination: "README.md"
               inline_badges: false
-              badge_order: DataType[Documenter{GitHubActions}, Documenter{GitLabCI}, Documenter{TravisCI}, GitHubActions, GitLabCI, TravisCI, AppVeyor, DroneCI, CirrusCI, Codecov, Coveralls, BlueStyleBadge, ColPracBadge, PkgEvalBadge]
+              badge_order: DataType[Documenter{GitHubActions}, Documenter{GitLabCI}, Documenter{TravisCI}, GitHubActions, GitLabCI, TravisCI, AppVeyor, DroneCI, CirrusCI, Codecov, Coveralls, BlueStyleBadge, ColPracBadge, PkgEvalBadge, SciMLStyleBadge]
               badge_off: DataType[]
             """
         test_show(rstrip(expected), sprint(show, MIME("text/plain"), Readme()))
@@ -68,7 +68,7 @@ end
                   file: "$(joinpath(TEMPLATES_DIR, "README.md"))"
                   destination: "README.md"
                   inline_badges: false
-                  badge_order: DataType[Documenter{GitHubActions}, Documenter{GitLabCI}, Documenter{TravisCI}, GitHubActions, GitLabCI, TravisCI, AppVeyor, DroneCI, CirrusCI, Codecov, Coveralls, BlueStyleBadge, ColPracBadge, PkgEvalBadge]
+                  badge_order: DataType[Documenter{GitHubActions}, Documenter{GitLabCI}, Documenter{TravisCI}, GitHubActions, GitLabCI, TravisCI, AppVeyor, DroneCI, CirrusCI, Codecov, Coveralls, BlueStyleBadge, ColPracBadge, PkgEvalBadge, SciMLStyleBadge]
                   badge_off: DataType[]
                 SrcDir:
                   file: "$(joinpath(TEMPLATES_DIR, "src", "module.jlt"))"


### PR DESCRIPTION
This allows to add the badge

[![Code Style: SciML](https://img.shields.io/badge/code_style-SciML-9558b2.svg)](https://github.com/SciML/SciMLStyle)

to the `README.md` by including the plugin `SciMLStyleBadge()` in `Template(; plugins = [...])`.