### PR TITLE
TagBot dispatch for custom registries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.55"
+version = "0.7.56"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/templates/github/workflows/TagBot.yml
+++ b/templates/github/workflows/TagBot.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   TagBot:
     {{#REGISTRY}}
-    if: github.event_name == 'workflow_dispatch' || github.actor == '{{{TRIGGER}}}' || (github.event_name == 'repository_dispatch' && github.event.client_payload.repository == {{{REGISTRY}}})
+    if: github.event_name == 'workflow_dispatch' || github.actor == '{{{TRIGGER}}}' || (github.event_name == 'repository_dispatch' && github.event.client_payload.repository == '{{{REGISTRY}}}')
     {{/REGISTRY}}
     {{^REGISTRY}}
     if: github.event_name == 'workflow_dispatch' || github.actor == '{{{TRIGGER}}}'

--- a/templates/github/workflows/TagBot.yml
+++ b/templates/github/workflows/TagBot.yml
@@ -22,7 +22,12 @@ permissions:
   statuses: read
 jobs:
   TagBot:
+    {{#REGISTRY}}
+    if: github.event_name == 'workflow_dispatch' || github.actor == '{{{TRIGGER}}}' || (github.event_name == 'repository_dispatch' && github.event.client_payload.repository == {{{REGISTRY}}})
+    {{/REGISTRY}}
+    {{^REGISTRY}}
     if: github.event_name == 'workflow_dispatch' || github.actor == '{{{TRIGGER}}}'
+    {{/REGISTRY}}
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/test/fixtures/WackyOptions/.github/workflows/TagBot.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/TagBot.yml
@@ -22,7 +22,7 @@ permissions:
   statuses: read
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'OtherUser'
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'OtherUser' || (github.event_name == 'repository_dispatch' && github.event.client_payload.repository == 'Foo/Bar')
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
When using plugin `TagBot(; registry="Foo/FooRegistry")`, support TagBot
dispatch on registry events.

CC @kdw503