### PR TITLE
fix(license): clarify interactive license names

### DIFF
--- a/src/plugins/license.jl
+++ b/src/plugins/license.jl
@@ -45,10 +45,30 @@ function prompt(::Type{License}, ::Type, ::Val{:name})
     # Move MIT to the top.
     deleteat!(options, findfirst(==("MIT"), options))
     pushfirst!(options, "MIT")
-    menu = RadioMenu(options; pagesize=length(options))
-    println("Select a license:")
+    menu = RadioMenu(map(license_display_name, options); pagesize=length(options))
+    println("Select a license (abbreviation - full name):")
     idx = request(menu)
     return options[idx]
 end
 
 customizable(::Type{License}) = (:name => String,)
+
+function license_display_name(name::AbstractString)
+    full_name = get(LICENSE_NAMES, name, name)
+    return full_name == name ? name : "$(name) - $(full_name)"
+end
+
+const LICENSE_NAMES = Dict(
+    "AGPL-3.0+" => "GNU Affero General Public License v3.0 or later",
+    "ASL" => "Apache License 2.0",
+    "BSD2" => "BSD 2-Clause License",
+    "BSD3" => "BSD 3-Clause License",
+    "EUPL-1.2+" => "European Union Public Licence 1.2 or later",
+    "GPL-2.0+" => "GNU General Public License v2.0 or later",
+    "GPL-3.0+" => "GNU General Public License v3.0 or later",
+    "ISC" => "ISC License",
+    "LGPL-2.1+" => "GNU Lesser General Public License v2.1 or later",
+    "LGPL-3.0+" => "GNU Lesser General Public License v3.0 or later",
+    "MIT" => "MIT License",
+    "MPL" => "Mozilla Public License 2.0",
+)

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -185,7 +185,11 @@ end
                 "COPYING", LF,       # Enter destination
                 CR,                  # Choose MIT for name (it's at the top)
             )
-            @test PT.interactive(License) == License(; destination="COPYING", name="MIT")
+            license = @suppress PT.interactive(License)
+            @test occursin("Select a license (abbreviation - full name):", license.output)
+            @test occursin("MIT - MIT License", license.output)
+            @test occursin("ASL - Apache License 2.0", license.output)
+            @test license.ret == License(; destination="COPYING", name="MIT")
         end
 
         @testset "Quotes" begin


### PR DESCRIPTION
Closes #448

## Why
The interactive license prompt currently shows bare abbreviations such as `ASL` and `MPL`, which makes it easy to misread the intended license. This change keeps the saved license keys unchanged while showing expanded names in the interactive menu.

## What changed
- render the license picker entries as `abbreviation - full name`
- keep the existing return values and ordering intact
- extend the interactive test to assert the clearer prompt text

## Verification
- static review of the focused diff
- local execution of Julia tests was not possible in this environment because `julia` is not installed (`julia: command not found`)
