### PR TITLE
CI: Bump setup-julia to v3 and fix macOS runner architecture matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.0"  # LTS
+          - "1.0"
           - "1.7" # interactive tests require <= 1.8
           - "1"    # Latest Release
         os:
@@ -36,6 +36,9 @@ jobs:
             arch: x86
           - os: windows-latest
             arch: x86
+          # Exclude macOS-latest x64 to prevent it running by default for all versions
+          - os: macOS-latest
+            arch: x64
         include:
           # Add specific version used to run the reference tests.
           # Must be kept in sync with version check in `test/runtests.jl`,
@@ -45,9 +48,20 @@ jobs:
           - os: ubuntu-latest
             version: 1.10.6
             arch: x64
+          # Intel macOS runner for older Julia versions
+          - version: "1.0"
+            os: macos-15-intel
+            arch: x64
+          - version: "1.7"
+            os: macos-15-intel
+            arch: x64
+          # Apple Silicon macOS runner for latest Julia version (aarch64)
+          - version: "1"
+            os: macOS-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -79,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - run: |


### PR DESCRIPTION
Detalis:

- Upgraded setup-julia: Bumped julia-actions/setup-julia from `@v2` to `@v3` for both the test and docs jobs, as suggested in the PR https://github.com/JuliaCI/PkgTemplates.jl/pull/527 by dependabot
- Resolved macOS Runner arch Issue, which probably caused CI error with the above PR: GitHub-hosted macOS-latest runners were run on Apple Silicon (arm64), causing architecture mismatch errors for older Julia versions like 1.0 and 1.7 that require x64 (Intel)
  - Excluded standard macOS-latest combinations globally from the default strategy matrix.
  - Explicitly mapped older Julia versions (1.0, 1.7) on macOS to the Intel runner (macos-15-intel) with x64.
  - Mapped the latest Julia version (1) on macOS to the Apple Silicon runner (macOS-latest) with aarch64.

-----

One question: In the CI file:

```
          # Add specific version used to run the reference tests.
          # Must be kept in sync with version check in `test/runtests.jl`,
          # and with the branch protection rules on the repository which
          # require this specific job to pass on all PRs
          # (see Settings > Branches > Branch protection rules).
          - os: ubuntu-latest
            version: 1.10.6
            arch: x64
```

The current LTS version is `1.10.11`. Should it still be kept `1.10.6` above?