### PR TITLE
Ci actions autoupdate

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,5 @@
 name: CI
-# Run on master, tags, or any pull request
+# Run on master, tags, any pull request, and manual triggering
 on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
@@ -7,6 +7,7 @@ on:
     branches: [master]
     tags: ["*"]
   pull_request:
+  workflow_dispatch:
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.
@@ -16,6 +17,8 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    env:
+      PT_SKIP_REFERENCE_TESTS: ${{ github.actor == 'dependabot[bot]' && 'true' || 'false' }}
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +63,7 @@ jobs:
             os: macOS-latest
             arch: aarch64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
@@ -92,7 +95,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'

--- a/.github/workflows/DependabotFixturesUpdate.yml
+++ b/.github/workflows/DependabotFixturesUpdate.yml
@@ -1,0 +1,67 @@
+name: Update Fixtures on Dependabot PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-fixtures:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Checkout the PR branch so we can commit and push back to it
+          ref: ${{ github.head_ref }}
+      
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1.10.6' # Exact version required for PkgTemplates reference tests
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.julia/artifacts
+          key: ubuntu-latest-test-artifacts-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ubuntu-latest-test-artifacts-
+
+      - uses: julia-actions/julia-buildpkg@latest
+
+      - name: Configure Git for PkgTemplates tests
+        run: |
+          git config --global user.name Tester
+          git config --global user.email te@st.er
+
+      - name: Run tests and update fixtures
+        env:
+          JULIA_REFERENCETESTS_UPDATE: "true"
+        run: |
+          julia --project=@. -e 'using Pkg; Pkg.test()'
+
+      - name: Commit and push changes
+        id: auto-commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Only proceed if there are changes in the test/fixtures/ directory
+          if [[ -n $(git status --porcelain test/fixtures/) ]]; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git add test/fixtures/
+            git commit -m "Auto-update test fixtures [skip ci]"
+            git push
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Warn maintainers
+        if: steps.auto-commit.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ **Notice for Maintainers:** Dependabot updated the CI actions, which caused the reference fixtures to be out of sync. This workflow automatically updated the fixtures in \`test/fixtures/\` and pushed the changes to this branch. **Please review the fixture diffs** in this PR to ensure the changes are expected before merging."

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -8,8 +8,8 @@ jobs:
     name: Julia Nightly - Ubuntu - x64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: nightly
           arch: x64

--- a/.github/workflows/TriggerDependabotUpdate.yml
+++ b/.github/workflows/TriggerDependabotUpdate.yml
@@ -1,0 +1,27 @@
+name: Template Actions Versions Tracker
+
+# This workflow is deliberately designed to never run automatically.
+# Its sole purpose is to trigger Dependabot PR to update CI actions versions
+# that are not used in PkgTemplates' own CI.yml.
+# The updated actions' versions will be used internally by PkgTemplates when 
+# generating packages.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  track-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harmless run
+        run: echo "This workflow is just for Dependabot to track template dependencies."
+      
+      # We use `if: false` so these steps are entirely skipped if the workflow is ever triggered manually.
+      - uses: julia-actions/cache@v3
+        if: false
+      - uses: julia-actions/julia-docdeploy@v1
+        if: false
+      - uses: julia-actions/julia-uploadcoveralls@v1
+        if: false
+      - uses: fredrikekre/runic-action@v1
+        if: false

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Dates = "<0.0.1, 1"
@@ -24,6 +25,7 @@ Parameters = "0.12, 0.13"
 Pkg = "<0.0.1, 1"
 REPL = "<0.0.1, 1"
 UUIDs = "<0.0.1, 1"
+YAML = "0.4.16"
 julia = "1"
 
 [extras]

--- a/src/PkgTemplates.jl
+++ b/src/PkgTemplates.jl
@@ -57,6 +57,7 @@ When implementing a new plugin, subtype this type to have full control over its 
 """
 abstract type Plugin end
 
+include("parse_ci_actions.jl")
 include("template.jl")
 include("plugin.jl")
 include("show.jl")

--- a/src/parse_ci_actions.jl
+++ b/src/parse_ci_actions.jl
@@ -24,12 +24,12 @@ end
 
 split_versions(results) = Dict{String, String}(split(r, "@", limit=2)[1] => r for r in results)
 
-function extract_ci_actions_versions()
-    base_dir = dirname(@__DIR__)
-    files_to_parse = [
-        joinpath(base_dir, ".github", "workflows", "CI.yml"),
-        joinpath(base_dir, ".github", "workflows", "TriggerDependabotUpdate.yml")
-    ]
+yml_files = [
+    joinpath(dirname(@__DIR__), ".github", "workflows", "CI.yml"),
+    joinpath(dirname(@__DIR__), ".github", "workflows", "TriggerDependabotUpdate.yml")
+]
+
+function extract_ci_actions_versions(files_to_parse = yml_files)
     results = String[]
     for f in files_to_parse
         if isfile(f)

--- a/src/parse_ci_actions.jl
+++ b/src/parse_ci_actions.jl
@@ -1,0 +1,47 @@
+module ExtractCiActionsVersions
+using YAML
+
+function collect_uses!(node::Dict, results::Vector{String})
+    for (k, v) in node
+        if k == "uses" && v isa AbstractString && occursin("@", v)
+            push!(results, v)
+        end
+        collect_uses!(v, results)
+    end
+    return results
+end
+
+function collect_uses!(node::AbstractVector, results::Vector{String})
+    for item in node
+        collect_uses!(item, results)
+    end
+    return results
+end
+
+function collect_uses!(node, results::Vector{String})
+    return results
+end
+
+split_versions(results) = Dict{String, String}(split(r, "@", limit=2)[1] => r for r in results)
+
+function extract_ci_actions_versions()
+    base_dir = dirname(@__DIR__)
+    files_to_parse = [
+        joinpath(base_dir, ".github", "workflows", "CI.yml"),
+        joinpath(base_dir, ".github", "workflows", "TriggerDependabotUpdate.yml")
+    ]
+    results = String[]
+    for f in files_to_parse
+        if isfile(f)
+            dict = YAML.load_file(f)
+            collect_uses!(dict, results)
+        end
+    end
+    unique!(results)
+    return split_versions(results)
+end
+
+end # module
+
+const CI_ACTIONS = ExtractCiActionsVersions.extract_ci_actions_versions()
+

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -93,6 +93,7 @@ function view(p::GitHubActions, t::Template, pkg::AbstractString)
     if p !== nothing
         v["BRANCH"] = p.branch
     end
+    merge!(v, CI_ACTIONS)
     return v
 end
 

--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -47,24 +47,24 @@ jobs:
             <</E_VERSION>>
         <</EXCLUDES>>
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: <<& actions/checkout>>
+      - uses: <<& julia-actions/setup-julia>>
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: <<& julia-actions/cache>>
+      - uses: <<& julia-actions/julia-buildpkg>>
+      - uses: <<& julia-actions/julia-runtest>>
       <<#HAS_CODECOV>>
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
+      - uses: <<& julia-actions/julia-processcoverage>>
+      - uses: <<& codecov/codecov-action>>
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
       <</HAS_CODECOV>>
       <<#HAS_COVERALLS>>
-      - uses: julia-actions/julia-uploadcoveralls@v1
+      - uses: <<& julia-actions/julia-uploadcoveralls>>
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       <</HAS_COVERALLS>>
@@ -77,13 +77,13 @@ jobs:
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: <<& actions/checkout>>
+      - uses: <<& julia-actions/setup-julia>>
         with:
           version: '1'
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-docdeploy@v1
+      - uses: <<& julia-actions/cache>>
+      - uses: <<& julia-actions/julia-buildpkg>>
+      - uses: <<& julia-actions/julia-docdeploy>>
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
@@ -100,8 +100,8 @@ jobs:
     name: Runic formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: fredrikekre/runic-action@v1
+      - uses: <<& actions/checkout>>
+      - uses: <<& fredrikekre/runic-action>>
         with:
           version: '1'
   <</HAS_RUNIC>>

--- a/test/fixtures/AllPlugins/.github/workflows/CI.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/CI.yml
@@ -30,16 +30,16 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
     name: Runic formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: fredrikekre/runic-action@v1
         with:
           version: '1'

--- a/test/fixtures/Basic/.github/workflows/CI.yml
+++ b/test/fixtures/Basic/.github/workflows/CI.yml
@@ -30,11 +30,11 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -30,14 +30,14 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -46,12 +46,12 @@ jobs:
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
@@ -30,11 +30,11 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest

--- a/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
@@ -30,11 +30,11 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest

--- a/test/fixtures/ParseCI/CI.yml
+++ b/test/fixtures/ParseCI/CI.yml
@@ -1,0 +1,120 @@
+name: CI
+# Run on master, tags, any pull request, and manual triggering
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
+  push:
+    branches: [master]
+    tags: ["*"]
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    env:
+      PT_SKIP_REFERENCE_TESTS: ${{ github.actor == 'dependabot[bot]' && 'true' || 'false' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.0"
+          - "1.7" # interactive tests require <= 1.8
+          - "1"    # Latest Release
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+          - x86
+        exclude:
+          # Test 32-bit only on Linux
+          - os: macOS-latest
+            arch: x86
+          - os: windows-latest
+            arch: x86
+          # Exclude macOS-latest x64 to prevent it running by default for all versions
+          - os: macOS-latest
+            arch: x64
+        include:
+          # Add specific version used to run the reference tests.
+          # Must be kept in sync with version check in `test/runtests.jl`,
+          # and with the branch protection rules on the repository which
+          # require this specific job to pass on all PRs
+          # (see Settings > Branches > Branch protection rules).
+          - os: ubuntu-latest
+            version: 1.10.6
+            arch: x64
+          # Intel macOS runner for older Julia versions
+          - version: "1.0"
+            os: macos-15-intel
+            arch: x64
+          - version: "1.7"
+            os: macos-15-intel
+            arch: x64
+          # Apple Silicon macOS runner for latest Julia version (aarch64)
+          - version: "1"
+            os: macOS-latest
+            arch: aarch64
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v5
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.arch }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - run: |
+          git config --global user.name Tester
+          git config --global user.email te@st.er
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+      - run: |
+          git config --global user.name name
+          git config --global user.email email
+          git config --global github.user username
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: doctest
+            using PkgTemplates
+            doctest(PkgTemplates)'
+      - run: julia --project=docs docs/make.jl
+        env:
+          JULIA_PKG_SERVER: ""
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -31,14 +31,14 @@ jobs:
           - x64
           - x86
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -47,12 +47,12 @@ jobs:
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/parse_ci.jl
+++ b/test/parse_ci.jl
@@ -1,0 +1,26 @@
+using Test
+using PkgTemplates
+
+@testset "CI Actions Versions" begin
+    # 1. Check if the set of CI actions has not changed
+    expected_keys = Set([
+        "actions/checkout",
+        "julia-actions/setup-julia",
+        "actions/cache",
+        "julia-actions/julia-buildpkg",
+        "julia-actions/julia-runtest",
+        "julia-actions/julia-processcoverage",
+        "codecov/codecov-action",
+        "julia-actions/cache",
+        "julia-actions/julia-docdeploy",
+        "julia-actions/julia-uploadcoveralls",
+        "fredrikekre/runic-action"
+    ])
+    
+    @test issetequal(keys(PkgTemplates.CI_ACTIONS), expected_keys)
+    
+    # 2. Check if the version of "actions/checkout" is 6 or higher
+    setup_julia_val = PkgTemplates.CI_ACTIONS["actions/checkout"]
+    parts = split(setup_julia_val, "@v"; limit=2)
+    @test VersionNumber(parts[2]) >= v"6"
+end

--- a/test/parse_ci.jl
+++ b/test/parse_ci.jl
@@ -1,6 +1,6 @@
 using Test
 using PkgTemplates
-
+using YAML
 @testset "CI Actions Versions" begin
     # 1. Check if the set of CI actions has not changed
     expected_keys = Set([
@@ -23,4 +23,20 @@ using PkgTemplates
     setup_julia_val = PkgTemplates.CI_ACTIONS["actions/checkout"]
     parts = split(setup_julia_val, "@v"; limit=2)
     @test VersionNumber(parts[2]) >= v"6"
+
+    # 3. Check collect_uses!
+    fixture_ci_file = joinpath(@__DIR__, "fixtures", "ParseCI", "CI.yml")
+    dict = YAML.load_file(fixture_ci_file)
+    results = String[]
+    PkgTemplates.ExtractCiActionsVersions.collect_uses!(dict, results)
+    @test "actions/checkout@v7" in results
+    @test "julia-actions/setup-julia@v3" in results
+    @test "codecov/codecov-action@v7" in results
+
+    # 4. Check extract_ci_actions_versions
+    versions = PkgTemplates.ExtractCiActionsVersions.extract_ci_actions_versions([fixture_ci_file])
+    @test versions["actions/checkout"] == "actions/checkout@v7"
+    @test versions["julia-actions/setup-julia"] == "julia-actions/setup-julia@v3"
+    @test versions["codecov/codecov-action"] == "codecov/codecov-action@v7"
+
 end

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -32,8 +32,13 @@ function test_reference(reference, comparison)
     println("Reference: $reference")
     println("Comparison: $comparison")
     update = false
-    if haskey(ENV, "JULIA_REFERENCETESTS_UPDATE")
+    if get(ENV, "JULIA_REFERENCETESTS_UPDATE", nothing) == "true"
         copy_file(comparison, reference)
+        if get(ENV, "CI", nothing) == "true"
+            @warn "The reference files have been updated, test therefore skipped. Please review the diff!"
+            @test true
+            return
+        end
     elseif PROMPT
         while true
             println("Update reference file? [y/n]")

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -38,6 +38,11 @@ function test_reference(reference, comparison)
         while true
             println("Update reference file? [y/n]")
             answer = lowercase(strip(readline()))
+            if isempty(answer)
+                # EOF: stdin is not connected (e.g. Pkg.test() subprocess).
+                @warn "stdin is not interactive, skipping reference file update"
+                break
+            end
             if startswith(answer, "y") || startswith(answer, "n")
                 # If the user chooses to update the reference file,
                 # replace its contents with the comparison file.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,7 @@ mktempdir() do dir
             include("template.jl")
             include("plugin.jl")
             include("show.jl")
+            include("parse_ci.jl")
 
             if VERSION < v"1.8"
                 # Interactive tests disabled on Julia Version >= 1.8 due to:
@@ -107,10 +108,10 @@ mktempdir() do dir
                 include("git.jl")
 
                 # Quite a bit of output depends on the Julia version,
-                # and the test fixtures are made with Julia 1.10.0
+                # and the test fixtures are made with Julia 1.10.6
                 # TODO: Keep this on the latest stable Julia version, and update
                 # the version used by the corresponding CI jobs in both `CI.yml` 
-                # and `dependabot-fixtures.yml` at the same time.
+                # and `DependabotFixturesUpdate.yml` at the same time.
                 REFERENCE_VERSION = v"1.10.6"
                 if VERSION == REFERENCE_VERSION
                     # Ideally we'd use `with_clean_gitconfig`, but it's way too slow.
@@ -118,7 +119,9 @@ mktempdir() do dir
                         "init.defaultBranch",
                         PT.DEFAULT_DEFAULT_BRANCH,
                     )
-                    if branch == PT.DEFAULT_DEFAULT_BRANCH
+                    if get(ENV, "PT_SKIP_REFERENCE_TESTS", "false") == "true"
+                        @info "Skipping reference tests (PT_SKIP_REFERENCE_TESTS=true)"
+                    elseif branch == PT.DEFAULT_DEFAULT_BRANCH
                         include("reference.jl")
                     else
                         "Skipping reference tests, init.defaultBranch is set"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,7 +109,8 @@ mktempdir() do dir
                 # Quite a bit of output depends on the Julia version,
                 # and the test fixtures are made with Julia 1.10.0
                 # TODO: Keep this on the latest stable Julia version, and update
-                # the version used by the corresponding CI job at the same time.
+                # the version used by the corresponding CI jobs in both `CI.yml` 
+                # and `dependabot-fixtures.yml` at the same time.
                 REFERENCE_VERSION = v"1.10.6"
                 if VERSION == REFERENCE_VERSION
                     # Ideally we'd use `with_clean_gitconfig`, but it's way too slow.


### PR DESCRIPTION
# Automate GitHub Actions Versioning in Templates via Dependabot

## Main Goal
Currently, the GitHub Actions versions embedded in PkgTemplates's generated `CI.yml` templates are hardcoded. This causes them to quickly become outdated, forcing maintainers to manually bump them. 
This PR completely automates this process by delegating the version tracking to Dependabot. When Dependabot updates an action in PkgTemplates's own CI, those updated versions are dynamically injected into the generated package templates.

## Proposed Changes

### 1. Dynamic Updates via Mustache Templating
All hardcoded action versions in `templates/github/workflows/CI.yml` (e.g., `actions/checkout@v2`) have been replaced with Mustache variables (e.g., `<<& actions/checkout>>`). 
- Introduced `src/parse_ci_actions.jl` to statically parse both `.github/workflows/CI.yml` and the newly introduced `.github/workflows/TriggerDependabotUpdate.yml`, extract the `uses:` versions, and expose them to the Mustache view.

### 2. Fixing `test/reference.jl` Issue
* **Infinite Loop Bug**: Fixed a bug discovered in the course of development of this PR when running the test suite via the REPL in a separate Terminal session. Apparently where stdin isn't fully interactive, `readline()` may repeatedly return an empty string (EOF), causing an infinite prompt loop. It now safely detects EOF and breaks out.

### 3. CI Architecture Changes
To automate the updates, including the updates of the reference tests fixtures, several interlocking workflows were introduced:

* **"Fake Workflow" as Action Versions Tracker**: Created `.github/workflows/TriggerDependabotUpdate.yml`. This workflow is designed to never run automatically. Its sole purpose is to list actions that are not present in `CI.yml` and *only* used in templates (like `julia-docdeploy` or `runic-action`) so Dependabot detects and updates them.
* **Auto-Updating Fixtures**: Created `.github/workflows/DependabotFixturesUpdate.yml`. This workflow runs *only* on Dependabot PRs. It runs the test suite with `JULIA_REFERENCETESTS_UPDATE="true"`. If the fixtures change, it automatically commits them back to the PR and uses the GitHub CLI to post a ⚠️ Warning comment, alerting maintainers to review the generated diffs.
* **Skipping Reference Tests for Dependabot**: When Dependabot bumps an action, the generated template changes, which breaks the reference tests in `test/fixtures/`. To prevent the main `CI.yml` from turning red, we introduced the `PT_SKIP_REFERENCE_TESTS` environment variable. If `github.actor == 'dependabot[bot]'`, the main CI cleanly skips the reference tests and passes. Should anything go wrong with the auto-update, it will be detected in a subsequent CI run e.g. on merging.
* **Broken Workflow Workaround**: While `test/reference.jl` already had a mechanism to auto-update fixtures via the `JULIA_REFERENCETESTS_UPDATE` environment variable, it has been intentionally designed to still fail the test (`@test :reference == :comparison`) after updating. This caused our new auto-updater workflow to crash abruptly. We patched this behavior so that when the environment variable is set on a CI runner, it issues a warning but otherwise passes the test, allowing the workflow to successfully commit the changes.
* **Manual Triggering Enabled**: In `CI.yml`, `on:   workflow_dispatch:` has been added. It was used during PR development, and I left it there, as it could be useful and otherwise does no harm.

## How to Test / Reproduce
If you want to test the entire Dependabot-triggered workflow on your own fork:
1. Ensure GitHub Actions are enabled in your fork (workflows are disabled by default in forks).
2. Ensure Dependabot is enabled in your fork's settings (`Settings -> Code security and analysis -> Dependabot version updates`).
3. Locally downgrade any action in `.github/workflows/CI.yml` or `TriggerDependabotUpdate.yml` (e.g., change `actions/checkout@v6` to `v4`). Commit and push to your default branch.
4. Force Dependabot to run immediately: Go to `Insights -> Dependency graph -> Dependabot -> Recent update jobs` and click **Check for updates**.
5. Dependabot will open a PR. You will see the main CI pass, the secondary auto-updater run, a new commit pushed with the updated `test/fixtures/`, and a warning comment placed on the PR!

**AI usage disclosure**: About 50% of the code changes have been generated by Gemini Pro 3.1 (High) within Antigravity. All human-produced code has been reviewed by Gemini and vice versa. All complex code changes have been additionally reviewed by Opus 4.6 in Antigravity.

P.S. As the reference fixtures are anyway updated in this PR, should we probably also bump the reference Julia version to the current LTS (i.e. 1.10.11)?